### PR TITLE
Update installing-boot9strap-(frogminer).txt

### DIFF
--- a/_pages/en_US/installing-boot9strap-(frogminer).txt
+++ b/_pages/en_US/installing-boot9strap-(frogminer).txt
@@ -141,8 +141,16 @@ This process will overwrite your game's save file!
 
 #### Section VI - Restoring Download Play
 
-1. Launch "Steel Diver: Sub Wars"
-1. If the exploit was successful, your device will have loaded the Homebrew Launcher
+1. Launch the Download Play application (this [icon]({{ "/images/download-play-icon.png" | absolute_url }})
+1. Press (L) + (Down) + (Select) at the same time to open the Rosalina menu
+1. Select "Miscellaneous options"
+1. Select "Switch the hb. title to the current app."
+1. Press (B) to continue
+1. Press (B) to return to the Rosalina main menu
+1. Press (B) to exit the Rosalina menu
+1. Press (Home), then close Download Play
+1. Launch the Download Play application
+1. Your device should load the Homebrew Launcher
 1. Launch Frogtool from the list of homebrew
 1. Select the "RESTORE clean DS Download Play" option
   + This will remove the Flipnote Studio application and exploit to restore the default functionality of DS Download Play


### PR DESCRIPTION
Can't launch steelhax after cfw is installed. Use Rosalina menu to access frogtool instead to restore clean ds download play