### PR TITLE
update to include twl test

### DIFF
--- a/_pages/en_US/installing-boot9strap-(frogminer).txt
+++ b/_pages/en_US/installing-boot9strap-(frogminer).txt
@@ -37,10 +37,10 @@ This process will overwrite your game's save file!
 
 #### Section I - Prep Work
 
-1. Go to System Settings, then "Internet Settings", then "Nintendo DS Connections".
-1. Press "OK".
-1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu.
-  + If the screen stays black or appears to freeze, you will not be able to use Frogminer. Return to [Get Started](get-started) and select an "All Versions" method.
+1. Go to System Settings, then "Internet Settings", then "Nintendo DS Connections"
+1. Press "OK"
+1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu
+  + If the screen stays black or appears to freeze, you will not be able to use Frogminer; return to [Get Started](get-started) and select an "All Versions" method
 1. Power off your device
 1. Insert your SD card into your computer
 1. Create a folder named `3ds` on the root of your SD card if it does not already exist

--- a/_pages/en_US/installing-boot9strap-(frogminer).txt
+++ b/_pages/en_US/installing-boot9strap-(frogminer).txt
@@ -40,8 +40,9 @@ This process will overwrite your game's save file!
 1. Open the System Settings app
 1. Open the Internet Settings section
 1. Select "Nintendo DS Connections"
-1. Press "OK". If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu and proceed to step 6.
-1. If the screen stays black or appears to freeze, you will not be able to use Frogminer. You will instead need to use [ntrboot](ntrboot) to access CFW
+1. Press "OK".
+1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu and proceed to step 6.
+  + If the screen stays black or appears to freeze, you will not be able to use Frogminer. Return to [Get Started](get-started) and select an "All Versions" method.
 1. Power off your device
 1. Insert your SD card into your computer
 1. Create a folder named `3ds` on the root of your SD card if it does not already exist

--- a/_pages/en_US/installing-boot9strap-(frogminer).txt
+++ b/_pages/en_US/installing-boot9strap-(frogminer).txt
@@ -37,6 +37,11 @@ This process will overwrite your game's save file!
 
 #### Section I - Prep Work
 
+1. Open the System Settings app
+1. Open the Internet Settings section
+1. Select "Nintendo DS Connections"
+1. Press "OK". If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu and proceed to step 6.
+1. If the screen stays black or appears to freeze, you will not be able to use Frogminer. You will instead need to use [ntrboot](ntrboot) to access CFW
 1. Power off your device
 1. Insert your SD card into your computer
 1. Create a folder named `3ds` on the root of your SD card if it does not already exist

--- a/_pages/en_US/installing-boot9strap-(frogminer).txt
+++ b/_pages/en_US/installing-boot9strap-(frogminer).txt
@@ -37,11 +37,9 @@ This process will overwrite your game's save file!
 
 #### Section I - Prep Work
 
-1. Open the System Settings app
-1. Open the Internet Settings section
-1. Select "Nintendo DS Connections"
+1. Go to System Settings, then "Internet Settings", then "Nintendo DS Connections".
 1. Press "OK".
-1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu and proceed to step 6.
+1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, exit this menu.
   + If the screen stays black or appears to freeze, you will not be able to use Frogminer. Return to [Get Started](get-started) and select an "All Versions" method.
 1. Power off your device
 1. Insert your SD card into your computer


### PR DESCRIPTION
some systems, usually due to prior uninstallation of cfw, have a broken twl firm and cannot use frogminer. it is pointless for such users to proceed through these steps only to find they can't do it. this can be detected from stock very easily and this pr includes steps for such a test