### PR TITLE
change steelminer site

### DIFF
--- a/_pages/en_US/installing-boot9strap-(frogminer).txt
+++ b/_pages/en_US/installing-boot9strap-(frogminer).txt
@@ -99,7 +99,7 @@ This process will overwrite your game's save file!
 1. Exit "Steel Diver: Sub Wars"
 1. Power off your device
 1. Insert your SD card into your computer
-1. Open [the Steelminer website](http://steelminer.jisagi.net/#Section_III) on your computer
+1. Open [the Steelminer Injector website](http://steelminer.jisagi.net/injector) on your computer
 1. Select your `movable.sed` file
 1. Select "Start!"
 1. Wait for the process to complete


### PR DESCRIPTION
Change steelminer site to injector-only rather than another guide.
This should alleviate fractured guide confusion

This change will need to be done for all translations but most are not up to date at this point anyway and should be reworked from the current en-us translation, in my opinion.