### PR TITLE
Add short explanations for components of the Seedminer finalization step 

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -27,7 +27,7 @@ During this process, we also setup programs such as the following:
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
 * The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest) *This allows `.cia` programs to have sound*
 * The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) *(the `.cia` and `.3dsx` files)*
-* The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
+* The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest) *Fixes a clock offset which causes the NAND clock to run fast*
 * The latest release of [Luma3DS Updater](https://github.com/KunoichiZ/lumaupdate/releases/latest) *(the `.cia` file)*
 
 ### Instructions

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -25,7 +25,7 @@ During this process, we also setup programs such as the following:
 * The latest release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/latest) *(the `.cia` file)*
 * The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest)
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
-* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest)
+* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest) *This allows `.cia` programs to have sound*
 * The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) *(the `.cia` and `.3dsx` files)*
 * The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
 * The latest release of [Luma3DS Updater](https://github.com/KunoichiZ/lumaupdate/releases/latest) *(the `.cia` file)*

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -18,7 +18,7 @@ During this process, we also setup programs such as the following:
 +  **Luma3DS Updater** *(updates your CFW installation easily)*
 +  **GodMode9** *(multipurpose tool which can do NAND and cartridge functions)*
 +  **Homebrew Launcher Loader** *(launches the Homebrew Launcher)*
-+  **DSP1** *(Allows CIA formatted games to use the 3DS sound)*
++  **DSP1** *(Allows homebrew applications to have sound)*
 +  **ctr-no-timeoffset** *(Removes the rtc offset so that the home menu and rtc timestamps match)*
 
 ### What You Need

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -18,6 +18,8 @@ During this process, we also setup programs such as the following:
 +  **Luma3DS Updater** *(updates your CFW installation easily)*
 +  **GodMode9** *(multipurpose tool which can do NAND and cartridge functions)*
 +  **Homebrew Launcher Loader** *(launches the Homebrew Launcher)*
++  **DSP1** *(Allows CIA formatted games to use the 3DS sound)*
++  **ctr-no-timeoffset** *(Removes the rtc offset so that the home menu and rtc timestamps match)*
 
 ### What You Need
 
@@ -25,9 +27,9 @@ During this process, we also setup programs such as the following:
 * The latest release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/latest) *(the `.cia` file)*
 * The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest)
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
-* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest) *This allows `.cia` programs to have sound*
+* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest)
 * The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) *(the `.cia` and `.3dsx` files)*
-* The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest) *Fixes a clock offset which causes the NAND clock to run fast*
+* The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
 * The latest release of [Luma3DS Updater](https://github.com/KunoichiZ/lumaupdate/releases/latest) *(the `.cia` file)*
 
 ### Instructions

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -18,8 +18,8 @@ During this process, we also setup programs such as the following:
 +  **Luma3DS Updater** *(updates your CFW installation easily)*
 +  **GodMode9** *(multipurpose tool which can do NAND and cartridge functions)*
 +  **Homebrew Launcher Loader** *(launches the Homebrew Launcher)*
-+  **DSP1** *(Allows homebrew applications to have sound)*
-+  **ctr-no-timeoffset** *(Removes the rtc offset so that the home menu and rtc timestamps match)*
++  **DSP1** *(allows homebrew applications to have sound)*
++  **ctr-no-timeoffset** *(removes the rtc offset so that the home menu and rtc timestamps match)*
 
 ### What You Need
 


### PR DESCRIPTION
Adds a short description of what DSP1 and `ctr-no-timeoffset` are responsible for in the *What You Need* section.

Thanks to users `ahrigatø` and `bungiefan(what does the guide say?)` from Discord, who explained what `DSP1` and `ctr-no-timeoffset` were for.