### PR TITLE
note about files not being in screenshot

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -55,7 +55,7 @@ During this process, we also setup programs such as the following:
     ![]({{ "/images/screenshots/finalizing-setup-file-layout.png" | absolute_url }})
     {: .notice--info}
 
-    Note that, depending on the method used to install boot9strap, your device's SD card may not have the `soundhax-usa-n3ds.m4a`, `otherapp.bin`, or `safehaxpayload.bin` files from the above screenshot.
+    Note that, depending on the method used to install boot9strap, your device's SD card may not have the `soundhax-usa-n3ds.m4a`, `otherapp.bin`, or `safehaxpayload.bin` files from the above screenshot or may have additional files not shown in the image.
     {: .notice--info}
 
 1. Reinsert your SD card into your device


### PR DESCRIPTION
clarification added for screenshot. not sure removing the screenshot outright makes sense considering people get confused with too many words when pictures dont break it up.