### PR TITLE
replace GM9 eject with poweroff

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -142,15 +142,15 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Press (A) on `boot9.bin` to select it
 1. Select "Copy to 0:/gm9/out"
 1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Hold (R) and press (B) at the same time to eject your SD card
+1. Press (Home) to bring up the action menu
+1. Select "Poweroff system" to power off your device
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, `essential.exefs`, and `boot9.bin` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
 1. Reinsert your SD card into your device
-1. Press (Start) to reboot your device
+1. Power on your device
 
 ___
 


### PR DESCRIPTION
removes potential unsafe removal and questions about "eject" vs "unmount" 