### PR TITLE
add header for notes/info section

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -154,6 +154,8 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 ___
 
+#### Information and Notes
+
 {% capture notice-10 %}
 You can now use Luma3DS Updater to update your Luma3DS to the latest version just by opening it and pressing (A).
 


### PR DESCRIPTION
Should help separate the notes from the guide itself. 
hopefully this will alleviate confusion over updating Luma right after installing it.