### PR TITLE
Updated NTRboot guide with info on R4i Gold 3DS plus

### DIFF
--- a/_pages/en_US/ntrboot.txt
+++ b/_pages/en_US/ntrboot.txt
@@ -4,7 +4,7 @@ title: "ntrboot"
 
 {% include toc title="Table of Contents" %}
 
-If your flashcart comes pre-flashed with ntrboot (or you have already flashed ntrboot to your flashcart), you can skip to [Installing boot9strap (ntrboot)](installing-boot9strap-(ntrboot)) for instructions on how to use it.
+If your flashcart comes pre-flashed with ntrboot, like the R4i Gold 3DS plus, or you have already flashed ntrboot to your flashcart, you can skip to [Installing boot9strap (ntrboot)](installing-boot9strap-(ntrboot)) for instructions on how to use it. If you have the R4i Gold 3DS plus, flip the switch inside the flashcart. 
 {: .notice--success}
 
 ### Required Reading


### PR DESCRIPTION
Made the NTRBoot guide more clear on the R4i Gold 3DS plus being preflashed and how to switch to the ntrboot mode.