### PR TITLE
edit requirements for clarity

### DIFF
--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -6,7 +6,7 @@ title: "Installing Boot9strap (Fredtool)"
 
 ### Required Reading
 
-This method of using Seedminer for further exploitation uses your `movable.sed` file to decrypt any DSiWare eShop title for the purposes of injecting an exploitable DSiWare title into the DS Internet Settings application. This requires you to already own (or download / buy) a DSiWare game from the eShop.
+This method of using Seedminer for further exploitation uses your `movable.sed` file to decrypt any DSiWare title for the purposes of injecting an exploitable DSiWare title into the DS Internet Settings application. This requires you to have a DSiWare backup, for example from BannerBomb or the DSiWare Dumper tool.
 
 This is a currently working implementation of the "FIRM partitions known-plaintext" exploit detailed [here](https://www.3dbrew.org/wiki/3DS_System_Flaws).
 


### PR DESCRIPTION
exploit summary still said eshop title
now it doesn't