### PR TITLE
standardization and rewording

### DIFF
--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -12,7 +12,7 @@ This is a currently working implementation of the "FIRM partitions known-plainte
 
 ### What You Need
 
-* A DSiWare Backup (such as from [BannerBomb3](bannerbomb3) or [DSiWare Dumper](dsidumper))
+* A DSiWare Backup (such as the one on SD root from [BannerBomb3](bannerbomb3) or [DSiWare Dumper](dsidumper))
 * Your `movable.sed` file from completing [Seedminer](seedminer)
 * The latest release of [Frogminer_save](https://github.com/zoogie/Frogminer/releases/latest)
 * The latest release of [b9sTool](https://github.com/zoogie/b9sTool/releases/latest)
@@ -40,8 +40,8 @@ This is a currently working implementation of the "FIRM partitions known-plainte
   + This file contains 2 dsiware backup files, one clean (unmodified) and one hax (exploited)
 1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card
   + This `<ID0>` will be the same one that you used in [Seedminer](seedminer)
-  + This `<ID1>` folder will be another 32 letter/number folder inside the ID0 folder
-  + The `Nintendo DSiWare` folder may need to be created inside the `<ID1>` folder
+  + This `<ID1>` folder will be another 32 letter/number folder inside the `<ID0>` folder
+  + If the `Nintendo DSiWare` folder does not exist, create it inside the `<ID1>` folder
 1. Copy the `42383841.bin` file from the `output/hax/` folder of the downloaded DSiWare archive (`fredtool_output.zip`) to the `Nintendo DSiWare` folder
 1. Reinsert your SD card into your device
 1. Power on your device


### PR DESCRIPTION
reworded the "create nintendo dsiware" to make it easier to see that it will have to be created if its not there
added some verbiage to the top of the what you need section to help remind (even after just 3 steps) that the file you need is probably on SD root