### PR TITLE
Add note about how to get essential.exefs if it is missing

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -142,6 +142,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, `essential.exefs`, and `boot9.bin` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
+  + If you are missing essential.exefs, please put your sd card back into your console, enter godmode9, navigate to `[S:] SYSNAND VIRTUAL`, select `essential.exefs` and select "Copy to 0:/gm9/out". You can now turn off your console, plug your sd into your computer and copy the files over.
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
 1. Reinsert your SD card into your device
 1. Power on your device


### PR DESCRIPTION
I've been informed that this should be created by Godmode9's backup prompt when you first run it, but I've seen several users ask about how to get this as they don't have it so I've added it in.