### PR TITLE
Add homebrew launcher to finalizing-setup.txt

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -25,6 +25,7 @@ During this process, we also setup programs such as the following:
 
 * The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest) *(the `.cia` file)*
 * The latest release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/latest) *(the `.cia` file)*
+* The latest release of [the Homebrew Launcher](https://github.com/fincs/new-hbmenu/releases/latest)
 * The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest)
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
 * The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest)
@@ -38,6 +39,7 @@ During this process, we also setup programs such as the following:
 
 1. Power off your device
 1. Insert your SD card into your computer
+1. Copy `boot.3dsx` to the root of your SD card if it does not already exist
 1. Create a folder named `3ds` on the root of your SD card if it does not already exist
 1. Create a folder named `cias` on the root of your SD card if it does not already exist
 1. Copy `ctr-no-timeoffset.3dsx` to the `/3ds/` folder on your SD card


### PR DESCRIPTION
ntrboot users may not have already copied the homebrew launcher, causing an exception when trying to launch it.