### PR TITLE
various changes to streamline text and reduce redundancy

### DIFF
--- a/_pages/en_US/homebrew-launcher-(pichaxx).txt
+++ b/_pages/en_US/homebrew-launcher-(pichaxx).txt
@@ -50,5 +50,5 @@ If you already have Pokemon Picross, this process will overwrite your game's sav
 
 ___
 
-### Continue to [DSiWare Dumper](dsidumper)
+### Continue to [Installing boot9strap (Frogtool)](installing-boot9strap-(frogtool))
 {: .notice--primary}

--- a/_pages/en_US/legacy-methods.txt
+++ b/_pages/en_US/legacy-methods.txt
@@ -14,8 +14,31 @@ However, "legacy" or outdated methods are kept here for various purposes. They w
 
 If you need help, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for assistance.
 
+#### Section I - Compatibility Test
+
+The following exploits make use of one of two DS-mode applications built into the 3DS: DS Internet Settings and DS Download Play.
+
+If both DS Internet Settings and DS Download Play fail to work, you will have to repair them with [TWLFix-3DS](https://github.com/MechanicalDragon0687/TWLFix-3DS/releases/) using a homebrew entrypoint, such as Pichaxx.
+
+#### DS Internet Settings Test (used for Fredtool)
+
+1. Go to System Settings, then "Internet Settings", then "Nintendo DS Connections"
+1. Press "OK"
+1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, the test was successful
+  + If the screen stays black or appears to freeze, the test has failed
+1. Exit this menu
+
+#### DS Download Play Test (used for Frogtool)
+
+1. Launch the Download Play application (![]({{ "/images/download-play-icon.png" | absolute_url }}){: height="24px" width="24px"})
+1. Select "Nintendo DS"
+1. If your device loads into a “Download software via DS Download Play” menu, the test was successful 
+  + If the screen stays black or appears to freeze, the test has failed
+1. Exit this menu
+
+___
+
 1. [BannerBomb3](bannerbomb3): Seedminer + BannerBomb3 + Fredtool
-1. [Pichaxx](homebrew-launcher-(pichaxx)): Seedminer + Pichaxx + DSiWare Dumper + Fredtool
-  + Pichaxx also has a sub method: [Frogtool](installing-boot9strap-(frogtool)): Seedminer + Pichaxx + Frogtool
-  
-All of these options should also finish with [Finalizing Setup](finalizing-setup).
+  + This method is recommended if your shoulder buttons do not work
+1. [Pichaxx](homebrew-launcher-(pichaxx)): Seedminer + Pichaxx + Frogtool
+  + This method is recommended if your DSiWare Management menu crashes

--- a/_pages/en_US/seedminer.txt
+++ b/_pages/en_US/seedminer.txt
@@ -20,15 +20,15 @@ This method uses a powerful graphics card to perform the calculations needed. A 
 
 While this test is not strictly necessary to perform the Seedminer exploit, the follow-up exploits to this do require this test to be performed and it would be a waste of time and effort to perform Seedminer without the ability to use the other exploits.
 
-There are two different methods for building on the Seedminer exploit (described in more detail at the bottom of this page), so even if this test fails you can still use another method.
+There are several different methods that build on the Seedminer exploit, so even if this test fails you can still use another method.
 
-#### DS Internet Settings Test (used for Fredtool)
+#### DSiWare Management Test (used for unSAFE_MODE)
 
-1. Go to System Settings, then "Internet Settings", then "Nintendo DS Connections"
-1. Press "OK"
-1. If your device loads into a "Nintendo Wi-Fi Connection Setup" menu, the test was successful
-  + If the screen stays black or appears to freeze, the test has failed and you will not be able to use the bannerbomb3 method which requires a functioning DS Internet Settings
-1. Exit this menu
+1. Go to System Settings, then "Data Management", then "DSiWare"
+1. If your console does not crash, the test was successful
+  + If the console crashes to the home menu, the test has failed and you will have to use a legacy method at the bottom of this page
+  + If you see a colored screen before the console crashes to the home menu, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask (in English) for someone there to assist you
+1. Exit to home menu
 
 #### Section II - Prep Work
 
@@ -60,7 +60,6 @@ There are two different methods for building on the Seedminer exploit (described
 1. Enter your device's Friend Code (with no spaces or dashes) into the "Your friend code" field
 1. Paste your device's 32 character long folder name into the "Your ID0" field
   + Do not attempt to enter the ID0 by hand. Ensure the ID0 is entered correctly by copying and pasting it from where you saved it in the previous section
-1. Complete the "I'm not a robot" captcha
 1. Select "Go"
   + If the site immediately goes to step 4, download your `movable.sed` file and continue with the next section.
 1. When prompted, use the "Register Friend" button on your device to add the friend code of the bot 3DS console
@@ -80,15 +79,15 @@ ___
 
 This method of using Seedminer for further exploitation uses your `movable.sed` file to take advantage of exploits in the SAFE_MODE firmware present on all 3DS units.
 
-This method is compatible with all regions, though CHN region is not covered by this guide.
+This method is compatible with all regions, though the CHN region is not covered by this guide.
 
-Continue to [unSAFE_MODE](installing-boot9strap-(usm))
+Continue to [Installing boot9strap (USM)](installing-boot9strap-(usm))
 {: .notice--primary}
 
 ___
 
 #### Legacy Methods
 
-These methods are outdated and not recommended unless you have a specific purpose for them, or you have been advised to use them.
+These methods are outdated and not recommended unless otherwise indicated.
 
 [Legacy Methods](legacy-methods)


### PR DESCRIPTION
Various changes have been made in this PR to aid in the transition to USM as the primary Seedminer method.

- Wording has been slightly changed when referring to other seedminer exploits, as they have been moved to the legacy methods page.
- The DS Internet Settings test has been replaced with a DSiWare management test, as the the latter is required for USM.
- "Continue to unSAFE_MODE" has been changed to "Continue to Installing boot9strap (USM)", in line with other pages on 3ds.hacks.guide.
- DS Internet and DS Download Play tests have been added to the Legacy Methods page, as well as a link to TWLFix-3DS should they be broken.
- Homebrew Launcher (Pichaxx) now links to Installing boot9strap (Frogtool), as Pichaxx + DSiWare Dumper + Fredtool is more of an edge case.