### PR TITLE
Add USM Title to sidebar pages list

### DIFF
--- a/_data/navigation/en_US.yml
+++ b/_data/navigation/en_US.yml
@@ -136,5 +136,8 @@ sidebar_pages:
     title: Installing boot9strap (Fredtool)
     url: installing-boot9strap-(fredtool)
   -
+    title: Installing boot9strap (USM)
+    url: installing-boot9strap-(usm)
+  -
     title: Finalizing Setup
     url: finalizing-setup


### PR DESCRIPTION
This will fix the progress tracking issue. It loops over the list of sidebar pages and then the js shows and hides them on demand.