### PR TITLE
Add filler data to DO_NOT_LAUNCH.firm

### DIFF
--- a/assets/DO_NOT_LAUNCH.firm
+++ b/assets/DO_NOT_LAUNCH.firm
@@ -1,0 +1,1 @@
+I'm a placeholder file to make the Luma chainloader appear.


### PR DESCRIPTION
This is a small change to add some text to assets/DO_NOT_LAUNCH.firm, as it seems that some browsers have trouble downloading the 0 byte file.