### PR TITLE
fix DO_NOT_LAUNCH.firm link in italian version of finalizing setup

### DIFF
--- a/_pages/it_IT/finalizing-setup.txt
+++ b/_pages/it_IT/finalizing-setup.txt
@@ -31,7 +31,7 @@ Durante la guida verranno anche configurate le seguenti applicazioni:
 * L'ultima versione di [FBI](https://github.com/Steveice10/FBI/releases/latest) *(i file `.cia` e `.3dsx`)*
 * Ultima versione di [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
 * L'ultima versione di [Luma3DS Updater](https://github.com/KunoichiZ/lumaupdate/releases/latest) *(il file `.cia`)*
-* [DO_NOT_LAUNCH.firm](assets/DO_NOT_LAUNCH.firm)
+* [DO_NOT_LAUNCH.firm](https://3ds.hacks.guide/assets/DO_NOT_LAUNCH.firm)
 
 ### Istruzioni
 


### PR DESCRIPTION
yes this isnt crowdin but bleh. the issue is caused by the link pointing to /assets/do_not_launch.firm. on the english version, this points to 3ds.hacks.guide/assets/do_not_launch.firm which is valid. on translations, this point to 3ds.hacks.guide/[language]/assets/do_not_launch.firm which is not valid. i imagine there's a more proper fix for this but i reckon this will work for now