### PR TITLE
installing boot9strap (soundhax) -> 1.0.0 to 11.3.0

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -6,7 +6,7 @@ title: "Get Started"
 
 ### Required Reading
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive. This means that, for example, the "from 9.0.0 to 9.2.0" row includes 9.0.0, 9.1.0, and 9.2.0.
+Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive.
 
 Your device version can be found at the bottom right of the top screen of the System Settings.
 
@@ -60,19 +60,10 @@ We believe SpotPass and StreetPass are also safe for use at this time.
   <tbody>
     <tr>
       <td style="text-align: center; font-weight: bold;">1.0.0</td>
-      <td style="text-align: center; font-weight: bold;">2.0.0</td>
-      <td style="text-align: center; font-weight: bold;">Update to latest version or use an "All Versions" Method</td>
-    </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">2.1.0</td>
-      <td style="text-align: center; font-weight: bold;">8.1.0</td>
+      <td style="text-align: center; font-weight: bold;">11.3.0</td>
       <td style="text-align: center; font-weight: bold;"><a href="installing-boot9strap-(soundhax)">Installing boot9strap (Soundhax)</a></td>
     </tr>
-    <tr>
-      <td style="text-align: center; font-weight: bold;">9.0.0</td>
-      <td style="text-align: center; font-weight: bold;">11.3.0</td>
-      <td style="text-align: center; font-weight: bold;"><a href="homebrew-launcher-(soundhax)">Homebrew Launcher (Soundhax)</a></td>
-    </tr><tr>
+	<tr>
       <td style="text-align: center; font-weight: bold;">11.4.0</td>
       <td style="text-align: center; font-weight: bold;">11.13.0</td>
       <td style="text-align: center; font-weight: bold;">Update to latest version or use an "All Versions" Method</td>

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -6,16 +6,7 @@ title: "Installing boot9strap (Soundhax)"
 
 ### Required Reading
 
-Soundhax (when combined with pre9otherapp) is compatible with versions 2.1.0 through 8.1.0 in the EUR, JPN, KOR, and USA regions.
-
-{% capture notice-1 %}
-
-Note that cartridge updates will only deliver updates to core features, such as the System Settings, Home Menu, etc. cartridge updates will not deliver updates to Nintendo 3DS Sound and Network features, such as System Transfer, Internet Browser, StreetPass Mii Plaza, or eShop.
-
-This means that using a cartridge update from a version containing an older Nintendo 3DS Sound version *(<2.1.0)* to one that introduced a newer Nintendo 3DS Sound version will break Soundhax! You will need an alternate method of entering the Homebrew Launcher such as [Installing boot9strap (Browser)](installing-boot9strap-(browser)) or [Installing boot9strap (MSET)](installing-boot9strap-(mset))!
-{% endcapture %}
-
-<div class="notice--warning">{{ notice-1 | markdownify }}</div>
+Soundhax (when combined with universal-otherapp) is compatible with versions 1.0.0 through 11.3.0 in all regions.
 
 ### What You Need
 
@@ -24,7 +15,7 @@ This means that using a cartridge update from a version containing an older Nint
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(standard boot9strap; not the `devkit` file, not the `ntr` file)*
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
-* The v1.2 release of [pre9otherapp](https://github.com/hax0kartik/pre9otherapp/releases/tag/v1.2) *(the `.bin` file corresponding to your firmware version)*
+* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/tag/v1.0.0)
 
 ### Instructions
 
@@ -33,12 +24,11 @@ This means that using a cartridge update from a version containing an older Nint
 1. Power off your device
 1. Insert your SD card into your computer
 1. Copy the Soundhax `.m4a` to the root of your SD card
-1. Copy the pre9otherapp payload to the root of your SD card and rename it to `otherapp.bin`
-  + If you do not see the `.bin` extension, do not add it to the end of the filename
+1. Copy `otherapp.bin` to the root of your SD card
 1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card
 1. Create a folder named `boot9strap` on the root of your SD card
 1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your SD card
-1. Copy `arm9.bin` from the SafeB9SInstaller `.zip` to the root of your SD card
+1. Copy `SafeB9SInstaller.bin` from the SafeB9SInstaller `.zip` to the root of your SD card
 1. Reinsert your SD card into your device
 1. Power on your device
 
@@ -56,7 +46,6 @@ This means that using a cartridge update from a version containing an older Nint
 1. Go to `/SDCARD`, then play "<3 nedwill 2016"
   + This may take many tries
   + If it freezes, force the console to power off by holding the power button, then try again
-  + If it fails more than ten times, try replacing your `otherapp.bin` with the [v2.0 release of pre9otherapp](https://github.com/hax0kartik/pre9otherapp/releases/tag/v2.0)
 
     ![]({{ "/images/screenshots/soundhax-launch.png" | absolute_url }})
     {: .notice--info}

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -15,7 +15,7 @@ Soundhax (when combined with universal-otherapp) is compatible with versions 1.0
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(standard boot9strap; not the `devkit` file, not the `ntr` file)*
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
-* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/tag/v1.0.0)
+* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest)
 
 ### Instructions
 

--- a/_pages/en_US/site-navigation.txt
+++ b/_pages/en_US/site-navigation.txt
@@ -8,7 +8,7 @@ sitemap: false
 **Popular**
 
 + [Finalizing Setup](finalizing-setup)
-+ [Homebrew Launcher (Soundhax)](homebrew-launcher-(soundhax))
++ [Installing boot9strap (Soundhax)](installing-boot9strap-(soundhax))
 + [Seedminer](seedminer)
 {% endcapture %}
 <div class="notice--info">{{ notice-1 | markdownify }}</div>


### PR DESCRIPTION
**Description**
Use `Installing boot9strap (Soundhax)` for all versions between 1.0.0 and 11.3.0, using universal-otherapp.

Changes in this PR:

get-started:
- Remove `This means that, for example, the "from 9.0.0 to 9.2.0" row includes 9.0.0, 9.1.0, and 9.2.0.` because it doesn't fit the current guide structure
- `Installing boot9strap (Soundhax)` -> from 1.0.0 to 11.3.0

installing-boot9strap-(soundhax):
- Remove USA/EUR/JPN/KOR region text ("all regions")
- Remove cart update notice
- Adjust instructions accordingly for use with universal-otherapp

site-navigation:
- Switch popular page from HBL-Soundhax to B9S-Soundhax