### PR TITLE
Add extra checks to prevent custom keyboards and Flipnote from being left on the system

### DIFF
--- a/_pages/en_US/uninstall-cfw.txt
+++ b/_pages/en_US/uninstall-cfw.txt
@@ -26,7 +26,16 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
 
 ### Instructions
 
-#### Section I - Safety Test
+#### Section I - Checking for Flipnote
+1. Open system settings
+1. Click Internet
+1. Click DS Conncetion Settings
+1. If you see Flipnote, you'll need to copy the clean save, follow these steps: https://3ds.hacks.guide/installing-boot9strap-(fredtool)
+1. Now close system settings
+1. Now open DS Download Play
+1. If it shows Flipnote, open Homebrew Launcher, run frogtool and hit RESTORE patched DS Download play
+
+#### Section II - Safety Test
 
 1. Power off your device
 1. Insert your SD card into your computer
@@ -50,8 +59,10 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
 1. When prompted, choose to decrypt and make a copy
 1. You should boot into the regular 3DS Home Menu. If you do, power your device off and continue to the next section
   + If you do NOT boot into the regular 3DS Home Menu, continuing with these instructions **WILL** brick your device. You should join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask (in English) for someone there to assist you
+1. Now go to system settings and attempt to setup an Internet Connection, go through all of the keyboards, if any of them crash the 3DS, you have a custom keyboard
+ + You should join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask (in English) for someone there to assist you with uninstalling it
   
-#### Section II - Prep Work
+#### Section III - Prep Work
 
 1. Power on your device
 1. Navigate to System Settings > Data Management > Nintendo 3DS > Software
@@ -63,7 +74,7 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
   + Failure to remove all CFW software from both the 3DS and DSiWare sections before uninstalling CFW may prevent or disable access to the Data Management menu after uninstalling CFW
 1. Power off your device
 
-#### Section III - Running Uninstall Script
+#### Section IV - Running Uninstall Script
 
 1. Launch GodMode9 by holding (Start) during boot
 1. Press (Home) to bring up the action menu


### PR DESCRIPTION
**Description**
There is no information here on checking for custom keyboards and flipnote, these should be checked for.
<!--What does this pull request do? Why is it needed?-->
It's needed because if hacked download play is left behind, then the user will need to reinstall Pichaxx, and then uninstall it.
