### PR TITLE
Update finalizing settup page (and add troubleshooting section) to avoid unnecessary CTR transfers on section II

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw-to-your-3ds), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw), then try updating again
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error. Try to get closer to your WiFi, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3ds, disable your fire wall, connect to a different wifi (such as a mobile hotspot)
+  + If this still gives you an error. Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
   + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
 
 #### Section III - Homebrew Launcher

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,6 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
+  + If this still gives you an error. Try to get closer to your WiFi, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3ds, disable your fire wall, connect to a different wifi (such as a mobile hotspot)
   + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
 
 #### Section III - Homebrew Launcher

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error. Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
+  + If this still gives you an error, Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
   + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
 
 #### Section III - Homebrew Launcher

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,8 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
-  + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw-to-your-3ds), then try updating again
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw), then try updating again
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw)
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -166,5 +166,5 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. reboot your WiFi router
 1. conect to a different WiFi conection (mobile hotspot, etc.)
 1. Nintendo servers may be down. Try again later
-1. If none of the suggestions above worked, [follow CTRTransfer](ctrtransfer), then try again
+1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,10 +158,12 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## WiFi connection errors after installing CFW
 
-1. You get an error while trying to use WiFi (during system update, loading the Browser/Eshop, ect.)
+1. You get an error while trying to use WiFi (during system update, loading the browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
+1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again
+1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -166,5 +166,5 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot
 1. Nintendo servers may be down. Try again later
-1. If none of the steps above worked, [follow CTRTransfer](ctrtransfer), then try updating again
+1. If you still get an error, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -161,7 +161,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
-1. Try deleting your WiFi connection, and signing into your Wifi network again
+1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
 1. Try conecting to a different WiFi conection (Mobile hotspot, ect.)
-1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
+1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,8 +158,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-  + You get "An error has occured" during system update
-  + Reboot your 3DS after each step and try updating again
+  + Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
 1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,7 +158,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
- Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+ Occasionally, updates may fail to install after installing CFW. To fix this, reboot your device after each step of this section, then try updating again.
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
@@ -166,6 +166,6 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot
-1. Nintendo servers may be down. Try again later
+1. Nintendo servers may be down; Try again later
 1. If you still get an error, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try rebooting your WiFi router
-1. Try deleting your WiFi connections, and signing into your Wifi again
+1. Try deleting your WiFi connections, then sign into your Wifi again
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -163,4 +163,5 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Try setting your DNS settings to "auto"
 1. Try deleting your WiFi connection, and signing into your Wifi network again
 1. Try rebooting your WiFi router
-1. Try conecting to a different WiFi conection
+1. Try conecting to a different WiFi conection (Mobile hotspot, ect.)
+1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -156,14 +156,15 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
 
-## WiFi connection errors after installing CFW
+## System update error after installing CFW
 
-1. You get an error while trying to use WiFi (during system update, loading the browser/Eshop, ect.)
-1. Try moving closer to your WiFi router, and rebooting your 3DS
-1. Try setting your DNS settings to "auto"
-1. Try rebooting your WiFi router
-1. Try deleting your WiFi connection/s, then sign into your Wifi again
-1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
-1. Try again later (Nintendo servers are down, ect.)
-1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again
+  + You get an error while trying to use WiFi (during system update)
+  + reboot your 3DS after each option and try again
+1. set your DNS settings to "Auto"
+1. move closer to your WiFi router
+1. delete your WiFi connection, then connect to your WiFi again
+1. reboot your WiFi router
+1. conect to a different WiFi conection (mobile hotspot, etc.)
+1. Nintendo servers may be down. Try again later
+1. If none of the suggestions above worked, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,10 +158,10 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## WiFi connection errors after installing CFW
 
-1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
+1. You get an error while trying to use WiFi (during system update, loading the Browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
-1. Try conecting to a different WiFi conection (Mobile hotspot, ect.)
+1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -6,7 +6,7 @@ title: "Troubleshooting"
 
 ### Required Reading
 
-If you are unable to boot your device, please look for the section relevant to you and follow the instructions.
+If you are unable to boot your. device, please look for the section relevant to you and follow the instructions.
 
 If you still cannot solve your issue and need to reach out for help, please paste the contents of all relevant .log files from the root of your SD card into a [Gist](https://gist.github.com/), then come for help prepared with a detailed description of your problem and what you've tried.
 

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,13 +158,13 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-  + You get an error while trying to use WiFi (during system update)
-  + reboot your 3DS after each option and try updating again
-1. set your DNS settings to "Auto"
-1. move closer to your WiFi router
-1. delete your WiFi connection, then connect to your WiFi again
-1. reboot your WiFi router
-1. conect to a different WiFi conection (mobile hotspot, etc.)
+  + You get "An error has occured" during system update
+  + Reboot your 3DS after each step and try updating again
+1. Set your DNS settings to "Auto"
+1. Move closer to your WiFi router
+1. Delete your WiFi connection, then reconnect to your WiFi again
+1. Reboot your WiFi router
+1. Connect to a different WiFi connection, like a mobile hotspot
 1. Nintendo servers may be down. Try again later
-1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try updating again
+1. If none of the steps above worked, [follow CTRTransfer](ctrtransfer), then try updating again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -161,8 +161,8 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You get an error while trying to use WiFi (during system update, loading the browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
-1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
+1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,7 +158,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+ Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try rebooting your WiFi router
-1. Try deleting your WiFi connections, then sign into your Wifi again
+1. Try deleting your WiFi connection/s, then sign into your Wifi again
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
-1. Update from Safe Mode by turning off the console, holding (A) + (Right Shoulder) + (Left Shoulder) + (D-Pad Up) on boot, and following the on screen prompts
+1. Update from Safe Mode by turning off the console, holding (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A) on boot, and following the on-screen prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
-1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts
+1. Update from Safe Mode by turning off the console, holding (A) + (Right Shoulder) + (Left Shoulder) + (D-Pad Up) on boot, and following the on screen prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -6,7 +6,7 @@ title: "Troubleshooting"
 
 ### Required Reading
 
-If you are unable to boot your. device, please look for the section relevant to you and follow the instructions.
+If you are unable to boot your device, please look for the section relevant to you and follow the instructions.
 
 If you still cannot solve your issue and need to reach out for help, please paste the contents of all relevant .log files from the root of your SD card into a [Gist](https://gist.github.com/), then come for help prepared with a detailed description of your problem and what you've tried.
 
@@ -155,3 +155,12 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Your device is bricked
 1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+
+## WiFi connection errors after installing CFW to your 3DS
+
+1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
+1. Try moving closer to your WiFi router, and rebooting your 3DS
+1. Try setting your DNS settings to "auto"
+1. Try deleting your WiFi connection, and signing into your Wifi network again
+1. Try rebooting your WiFi router
+1. Try conecting to a different WiFi conection

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,6 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
   + Reboot your 3DS after each step and try updating again
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
+1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,7 +158,8 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-  + Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
 1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -159,12 +159,12 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 ## System update error after installing CFW
 
   + You get an error while trying to use WiFi (during system update)
-  + reboot your 3DS after each option and try again
+  + reboot your 3DS after each option and try updating again
 1. set your DNS settings to "Auto"
 1. move closer to your WiFi router
 1. delete your WiFi connection, then connect to your WiFi again
 1. reboot your WiFi router
 1. conect to a different WiFi conection (mobile hotspot, etc.)
 1. Nintendo servers may be down. Try again later
-1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try again
+1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try updating again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -156,7 +156,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
 
-## WiFi connection errors after installing CFW to your 3DS
+## WiFi connection errors after installing CFW
 
 1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS


### PR DESCRIPTION
updates finalizing setup page section II to link to a (new) troubleshooting section to avoid unnecessary CTRtransfers when your device fails to update

adds troubleshooting section on the troubleshooting page.
changes finalizing setup page to link to this troubleshooting section.