### PR TITLE
Make instruction on booting GodMode9 clearer

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -103,7 +103,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 #### Section VI - CTRNAND Luma3DS
 
 1. Power off your device
-1. Launch GodMode9 by holding (Start) during boot
+1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9.
 1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it has completed
 1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
 1. Press (Home) to bring up the action menu

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -103,7 +103,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 #### Section VI - CTRNAND Luma3DS
 
 1. Power off your device
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9.
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it has completed
 1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
 1. Press (Home) to bring up the action menu


### PR DESCRIPTION

**Description**

A handful of people have been confused about how to load GodMode9 in Section VI, and have accidentally pressed the button too late or tried to time the START button, etc. The fool-proof explanation on how to load GodMode9 or the chainloader menu appears to be to press and hold START, and keep holding the START button when powering on the console.

Section VI, step 2 makes this clearer.
