### PR TITLE
get-started (n3ds/o3ds): Add note about browser version/region

### DIFF
--- a/_pages/en_US/get-started-(new-3ds).txt
+++ b/_pages/en_US/get-started-(new-3ds).txt
@@ -18,6 +18,8 @@ While we believe that custom firmware is safe for online use, there have been on
 
 ### Version Table
 
+The letter and number after the system version (for example, 11.14.0-**46U**) is not relevant in this version table.
+
 <table>
   <colgroup>
     <col span="1" style="width: 10%;">

--- a/_pages/en_US/get-started-(old-3ds).txt
+++ b/_pages/en_US/get-started-(old-3ds).txt
@@ -18,6 +18,8 @@ While we believe that custom firmware is safe for online use, there have been on
 
 ### Version Table
 
+The letter and number after the system version (for example, 11.14.0-**46U**) is not relevant in this version table.
+
 <table>
   <colgroup>
     <col span="1" style="width: 10%;">


### PR DESCRIPTION
Adds note to `Get Started (New 3DS)` and `Get Started (Old 3DS)` above the version table to ignore the browser version/region.

![image](https://user-images.githubusercontent.com/27717444/112093576-e6c43a00-8b56-11eb-9e27-3f8e31416c5f.png)
