### PR TITLE
Add dumping romfs and exefs onto the gm9 usage page

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw-to-your-3ds), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw), then try updating again
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error. Try to get closer to your WiFi, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3ds, disable your fire wall, connect to a different wifi (such as a mobile hotspot)
+  + If this still gives you an error. Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
   + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
 
 #### Section III - Homebrew Launcher

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,6 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
+  + If this still gives you an error. Try to get closer to your WiFi, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3ds, disable your fire wall, connect to a different wifi (such as a mobile hotspot)
   + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
 
 #### Section III - Homebrew Launcher

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error. Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
+  + If this still gives you an error, Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
   + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
 
 #### Section III - Homebrew Launcher

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,8 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, Try to get closer to your WiFi router, restart your WiFi router (unplug for 10 seconds, plug back in), restart your 3DS, disable your fire wall, connect to a different WiFi (such as a mobile hotspot)
-  + If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw-to-your-3ds), then try updating again
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#wifi-connection-errors-after-installing-cfw), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw), then try updating again
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw), then try updating again
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw)
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -122,6 +122,19 @@ Insert the game cartridge you intend to dump into your device
   + **NDS Game Cartridge:** Press (A) on `[TitleID].trim.nds` to select it, then select "Copy to 0:/gm9/out"
 1. Your installable `.cia` or non-installable `.nds` formatted file will be outputted to the `/gm9/out/` folder on your SD card
 
+## Dumping a Game Cartridges romfs/exefs
+
+1. Insert a game cartrige you wish to dump from
+1. Launch GodMode9 by holding (Start) during boot
+1. Hover over "GAMECART ()"
+1. Press (A), wait (could take up to 20 seconds)
+1. Hover over the bigest file ending with `.3ds` and press (A)
+1. Select "NCCH image options"
+1. Select "Mount image to drive"
+1. Press (A) to continue
+1. Hover over `exefs.bin`, hold (R) and press (A) to open "directory options", select "copy to 0:/gm9/out", do the same with `romfs.bin`
+  + The dumped files will be in `/gm9/out`
+
 ## Dumping a Title
 
 1. Launch GodMode9 by holding (Start) during boot
@@ -129,10 +142,31 @@ Insert the game cartridge you intend to dump into your device
   + **User Installed Title**: `[A:] SYSNAND SD`
   + **System Title**: `[1:] SYSNAND CTRNAND`
 1. Hold (R) and press (A) at the same time to open the drive options
-1. Select "Search for titles"
+1. Select "Open title manager"
 1. Press (A) to continue
 1. Press (A) on the `.tmd` file to select it, then select "TMD file options...", then select "Build CIA (standard)"
 1. Your installable `.cia` formatted file will be outputted to the `/gm9/out/` folder on your SD card
+
+## Dumping a Titles romfs/exefs
+
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Hover over the drive applicable to the type of title you wish to dump files for:
+  + **User Installed `Title: [A:] SYSNAND SD`
+  + **System Title: `[1:] SYSNAND CTRNAND`
+1. Hold (R) and press (A) at the same time to open the drive options
+1. Select “open title manager”
+1. Press (A) to continue
+1. Press (A) on the game you wish to dump the romfs/exefs from 
+  + accent letters will be a `?`, like the e in pokemon
+1. Press (A) on "open title folder"
+1. Then press (A) on the bigest file ending in `.app`(the file size is on the right of each file in gm9)
+  + `Byte` is smaller than `kb`, `kb` is smaller than `mb`, `mb` is smaller than `gb`. Example: 1.2 gb is bigger than 1.4 mb and so on
+1. Select (A) on "NCCH image options"
+1. Select (A) on "Mount image to drive"
+1. Press (A) to continue
+1. Hover over `exefs.bin`, hold (R) and press (A) to open "directory options", select "copy to 0:/gm9/out". Do the same with `romfs.bin`
+  + The dumped files will be in `/gm9/out`
+
 
 ## Converting a .3DS to .CIA
 

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -166,5 +166,5 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. reboot your WiFi router
 1. conect to a different WiFi conection (mobile hotspot, etc.)
 1. Nintendo servers may be down. Try again later
-1. If none of the suggestions above worked, [follow CTRTransfer](ctrtransfer), then try again
+1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,10 +158,12 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## WiFi connection errors after installing CFW
 
-1. You get an error while trying to use WiFi (during system update, loading the Browser/Eshop, ect.)
+1. You get an error while trying to use WiFi (during system update, loading the browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
+1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again
+1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -166,5 +166,5 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot
 1. Nintendo servers may be down. Try again later
-1. If none of the steps above worked, [follow CTRTransfer](ctrtransfer), then try updating again
+1. If you still get an error, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -161,7 +161,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
-1. Try deleting your WiFi connection, and signing into your Wifi network again
+1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
 1. Try conecting to a different WiFi conection (Mobile hotspot, ect.)
-1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again
+1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,8 +158,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-  + You get "An error has occured" during system update
-  + Reboot your 3DS after each step and try updating again
+  + Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
 1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,7 +158,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
- Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+ Occasionally, updates may fail to install after installing CFW. To fix this, reboot your device after each step of this section, then try updating again.
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
@@ -166,6 +166,6 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot
-1. Nintendo servers may be down. Try again later
+1. Nintendo servers may be down; Try again later
 1. If you still get an error, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try rebooting your WiFi router
-1. Try deleting your WiFi connections, and signing into your Wifi again
+1. Try deleting your WiFi connections, then sign into your Wifi again
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -163,4 +163,5 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Try setting your DNS settings to "auto"
 1. Try deleting your WiFi connection, and signing into your Wifi network again
 1. Try rebooting your WiFi router
-1. Try conecting to a different WiFi conection
+1. Try conecting to a different WiFi conection (Mobile hotspot, ect.)
+1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try updating again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -156,14 +156,15 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
 
-## WiFi connection errors after installing CFW
+## System update error after installing CFW
 
-1. You get an error while trying to use WiFi (during system update, loading the browser/Eshop, ect.)
-1. Try moving closer to your WiFi router, and rebooting your 3DS
-1. Try setting your DNS settings to "auto"
-1. Try rebooting your WiFi router
-1. Try deleting your WiFi connection/s, then sign into your Wifi again
-1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
-1. Try again later (Nintendo servers are down, ect.)
-1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again
+  + You get an error while trying to use WiFi (during system update)
+  + reboot your 3DS after each option and try again
+1. set your DNS settings to "Auto"
+1. move closer to your WiFi router
+1. delete your WiFi connection, then connect to your WiFi again
+1. reboot your WiFi router
+1. conect to a different WiFi conection (mobile hotspot, etc.)
+1. Nintendo servers may be down. Try again later
+1. If none of the suggestions above worked, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,10 +158,10 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## WiFi connection errors after installing CFW
 
-1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
+1. You get an error while trying to use WiFi (during system update, loading the Browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
-1. Try conecting to a different WiFi conection (Mobile hotspot, ect.)
+1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -6,7 +6,7 @@ title: "Troubleshooting"
 
 ### Required Reading
 
-If you are unable to boot your device, please look for the section relevant to you and follow the instructions.
+If you are unable to boot your. device, please look for the section relevant to you and follow the instructions.
 
 If you still cannot solve your issue and need to reach out for help, please paste the contents of all relevant .log files from the root of your SD card into a [Gist](https://gist.github.com/), then come for help prepared with a detailed description of your problem and what you've tried.
 

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,13 +158,13 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-  + You get an error while trying to use WiFi (during system update)
-  + reboot your 3DS after each option and try updating again
-1. set your DNS settings to "Auto"
-1. move closer to your WiFi router
-1. delete your WiFi connection, then connect to your WiFi again
-1. reboot your WiFi router
-1. conect to a different WiFi conection (mobile hotspot, etc.)
+  + You get "An error has occured" during system update
+  + Reboot your 3DS after each step and try updating again
+1. Set your DNS settings to "Auto"
+1. Move closer to your WiFi router
+1. Delete your WiFi connection, then reconnect to your WiFi again
+1. Reboot your WiFi router
+1. Connect to a different WiFi connection, like a mobile hotspot
 1. Nintendo servers may be down. Try again later
-1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try updating again
+1. If none of the steps above worked, [follow CTRTransfer](ctrtransfer), then try updating again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -161,8 +161,8 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You get an error while trying to use WiFi (during system update, loading the browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
-1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try rebooting your WiFi router
+1. Try deleting your WiFi connections, and signing into your Wifi again
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,7 +158,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+ Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Try moving closer to your WiFi router, and rebooting your 3DS
 1. Try setting your DNS settings to "auto"
 1. Try rebooting your WiFi router
-1. Try deleting your WiFi connections, then sign into your Wifi again
+1. Try deleting your WiFi connection/s, then sign into your Wifi again
 1. Try conecting to a different WiFi conection (mobile hotspot, ect.)
 1. Try again later (Nintendo servers are down, ect.)
 1. If this still gives you an error, [follow CTRTransfer](ctrtransfer), then try again

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
-1. Update from Safe Mode by turning off the console, holding (A) + (Right Shoulder) + (Left Shoulder) + (D-Pad Up) on boot, and following the on screen prompts
+1. Update from Safe Mode by turning off the console, holding (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A) on boot, and following the on-screen prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,7 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
-1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts
+1. Update from Safe Mode by turning off the console, holding (A) + (Right Shoulder) + (Left Shoulder) + (D-Pad Up) on boot, and following the on screen prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -6,7 +6,7 @@ title: "Troubleshooting"
 
 ### Required Reading
 
-If you are unable to boot your. device, please look for the section relevant to you and follow the instructions.
+If you are unable to boot your device, please look for the section relevant to you and follow the instructions.
 
 If you still cannot solve your issue and need to reach out for help, please paste the contents of all relevant .log files from the root of your SD card into a [Gist](https://gist.github.com/), then come for help prepared with a detailed description of your problem and what you've tried.
 
@@ -155,3 +155,12 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Your device is bricked
 1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+
+## WiFi connection errors after installing CFW to your 3DS
+
+1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
+1. Try moving closer to your WiFi router, and rebooting your 3DS
+1. Try setting your DNS settings to "auto"
+1. Try deleting your WiFi connection, and signing into your Wifi network again
+1. Try rebooting your WiFi router
+1. Try conecting to a different WiFi conection

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -162,6 +162,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
   + Reboot your 3DS after each step and try updating again
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
+1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -158,7 +158,8 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 
 ## System update error after installing CFW
 
-  + Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+Occasionally, updates may fail to install after installing CFW. To fix this, reboot your 3DS after each step of this section, then try updating again.
+
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
 1. Update from Safe Mode by turning off the console, holding L+R+Up+A on boot, and following the prompts

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -159,12 +159,12 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 ## System update error after installing CFW
 
   + You get an error while trying to use WiFi (during system update)
-  + reboot your 3DS after each option and try again
+  + reboot your 3DS after each option and try updating again
 1. set your DNS settings to "Auto"
 1. move closer to your WiFi router
 1. delete your WiFi connection, then connect to your WiFi again
 1. reboot your WiFi router
 1. conect to a different WiFi conection (mobile hotspot, etc.)
 1. Nintendo servers may be down. Try again later
-1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try again
+1. If none of the options above worked, [follow CTRTransfer](ctrtransfer), then try updating again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -156,7 +156,7 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
 
-## WiFi connection errors after installing CFW to your 3DS
+## WiFi connection errors after installing CFW
 
 1. You get an error while trying to use WiFi (During system update, loading the Browser/Eshop, ect.)
 1. Try moving closer to your WiFi router, and rebooting your 3DS


### PR DESCRIPTION
This pull request adds how to dump romfs and exefs from installed titles and gamecarts. this is to give people a direct guide to link to when someone asks how to dump them for whatever reason (be it making a mod for a game, or something else). It could also be used for dumping other files from titles and gamecarts for whatever reason.

 I have seen many people now come into the assistance channels asking how to dump the romfs and exefs. or this just coming up in conversation and asking how to do it