### PR TITLE
Gm9 romfs and exef

### DIFF
--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -165,7 +165,7 @@ Insert the game cartridge you intend to dump into your device
 1. Select (A) on "Mount image to drive"
 1. Press (A) to continue
 1. Hover over the `exefs` directory, hold (R) and press (A) to open "directory options"
-1. select "copy to 0:/gm9/out". Do the same with the `romfs.bin` directory
+1. select "copy to 0:/gm9/out". Do the same with the `romfs` directory
   + The dumped files will be in `/gm9/out`
 
 ## Converting a .3DS to .CIA

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -150,10 +150,10 @@ Insert the game cartridge you intend to dump into your device
 ## Dumping a Title's contents
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Navigate to the drive applicable to the type of title you wish to dump the contents of:
+1. Hover over the drive applicable to the type of title you wish to dump the contents of:
   + **User Installed `Title: [A:] SYSNAND SD`
   + **System Title: `[1:] SYSNAND CTRNAND`
-1. Hold (R) and press (A) at the same time to open the directory options
+1. Hold (R) and press (A) at the same time to open the drive options
 1. Select “Open title manager”
 1. Press (A) to continue
 1. Press (A) on the title you wish to dump the romfs/exefs from 
@@ -164,7 +164,7 @@ Insert the game cartridge you intend to dump into your device
 1. Select (A) on "NCCH image options"
 1. Select (A) on "Mount image to drive"
 1. Press (A) to continue
-1. Hover over the `exefs` directory, hold (R) and press (A) to open "directory options"
+1. Hover over the `exefs` directory, hold (R) and press (A) to open the directory options
 1. select "copy to 0:/gm9/out". Do the same with the `romfs` directory
   + The dumped files will be in `/gm9/out`
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -156,8 +156,9 @@ Insert the game cartridge you intend to dump into your device
 1. Hold (R) and press (A) at the same time to open the drive options
 1. Select “open title manager”
 1. Press (A) to continue
-1. Press (A) on the game you wish to dump the romfs/exefs from 
+1. Press (A) on the title you wish to dump the romfs/exefs from 
   + accent letters will be a `?`, like the e in pokemon
+  + Titles will have the title ID before the name
 1. Press (A) on "open title folder"
 1. Then press (A) on the bigest file ending in `.app`(the file size is on the right of each file in gm9)
   + `Byte` is smaller than `kb`, `kb` is smaller than `mb`, `mb` is smaller than `gb`. Example: 1.2 gb is bigger than 1.4 mb and so on

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -115,24 +115,57 @@ Insert the game cartridge you intend to dump into your device
 
 <div class="notice--info">{{ notice | markdownify }}</div>
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Launch GodMode9 by holding (Start) during boot
 1. Navigate to `[C:] GAMECART`
 1. Follow the steps applicable to your game cartridge:
   + **3DS Game Cartridge:** Press (A) on `[TitleID].trim.3ds` to select it, then select "NCSD image options...", then select "Build CIA from file"
   + **NDS Game Cartridge:** Press (A) on `[TitleID].trim.nds` to select it, then select "Copy to 0:/gm9/out"
 1. Your installable `.cia` or non-installable `.nds` formatted file will be outputted to the `/gm9/out/` folder on your SD card
 
+## Dumping a Game Cartridges romfs/exefs
+
+1. Insert a game cartrige you wish to dump from
+1. Launch GodMode9 by holding (Start) during boot
+1. Hover over "GAMECART ()"
+1. Press (A), wait (could take up to 20 seconds)
+1. Hover over the bigest file ending with `.3ds` and press (A)
+1. Select "NCCH image options"
+1. Select "Mount image to drive"
+1. Press (A) to continue
+1. Hover over `exefs.bin`, hold (R) and press (A) to open "directory options", select "copy to 0:/gm9/out", do the same with `romfs.bin`
+  + The dumped files will be in `/gm9/out`
+
 ## Dumping a Title
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Launch GodMode9 by holding (Start) during boot
 1. Hover over the drive applicable to the type of title you wish to dump:
   + **User Installed Title**: `[A:] SYSNAND SD`
   + **System Title**: `[1:] SYSNAND CTRNAND`
 1. Hold (R) and press (A) at the same time to open the drive options
-1. Select "Search for titles"
+1. Select "Open title manager"
 1. Press (A) to continue
 1. Press (A) on the `.tmd` file to select it, then select "TMD file options...", then select "Build CIA (standard)"
 1. Your installable `.cia` formatted file will be outputted to the `/gm9/out/` folder on your SD card
+
+## Dumping a Titles romfs/exefs
+
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Hover over the drive applicable to the type of title you wish to dump files for:
+  + **User Installed `Title: [A:] SYSNAND SD`
+  + **System Title: `[1:] SYSNAND CTRNAND`
+1. Hold (R) and press (A) at the same time to open the drive options
+1. Select “open title manager”
+1. Press (A) to continue
+1. Press (A) on the game you wish to dump the romfs/exefs from 
+  + accent letters will be a `?`, like the e in pokemon
+1. Press (A) on "open title folder"
+1. Then press (A) on the bigest file ending in `.app`(the file size is on the right of each file in gm9)
+  + `Byte` is smaller than `kb`, `kb` is smaller than `mb`, `mb` is smaller than `gb`. Example: 1.2 gb is bigger than 1.4 mb and so on
+1. Select (A) on "NCCH image options"
+1. Select (A) on "Mount image to drive"
+1. Press (A) to continue
+1. Hover over `exefs.bin`, hold (R) and press (A) to open "directory options", select "copy to 0:/gm9/out". Do the same with `romfs.bin`
+  + The dumped files will be in `/gm9/out`
 
 ## Converting a .3DS to .CIA
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -115,7 +115,7 @@ Insert the game cartridge you intend to dump into your device
 
 <div class="notice--info">{{ notice | markdownify }}</div>
 
-1. Launch GodMode9 by holding (Start) during boot
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Navigate to `[C:] GAMECART`
 1. Follow the steps applicable to your game cartridge:
   + **3DS Game Cartridge:** Press (A) on `[TitleID].trim.3ds` to select it, then select "NCSD image options...", then select "Build CIA from file"
@@ -125,7 +125,7 @@ Insert the game cartridge you intend to dump into your device
 ## Dumping a Game Cartridges romfs/exefs
 
 1. Insert a game cartrige you wish to dump from
-1. Launch GodMode9 by holding (Start) during boot
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Hover over "GAMECART ()"
 1. Press (A), wait (could take up to 20 seconds)
 1. Hover over the bigest file ending with `.3ds` and press (A)
@@ -137,7 +137,7 @@ Insert the game cartridge you intend to dump into your device
 
 ## Dumping a Title
 
-1. Launch GodMode9 by holding (Start) during boot
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Hover over the drive applicable to the type of title you wish to dump:
   + **User Installed Title**: `[A:] SYSNAND SD`
   + **System Title**: `[1:] SYSNAND CTRNAND`

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -131,7 +131,7 @@ Insert the game cartridge you intend to dump into your device
 1. Select "NCCH image options"
 1. Select "Mount image to drive"
 1. Press (A) to continue
-1. Hover over the `exefs` directory, hold (R) and press (A) to open "directory options"
+1. Hover over the `exefs` directory, hold (R) and press (A) to open the directory options
 1. Select "copy to 0:/gm9/out", do the same with the `romfs` directory
   + The dumped files will be in `/gm9/out`
 
@@ -141,7 +141,7 @@ Insert the game cartridge you intend to dump into your device
 1. Navigate to the drive applicable to the type of title you wish to dump:
   + **User Installed Title**: `[A:] SYSNAND SD`
   + **System Title**: `[1:] SYSNAND CTRNAND`
-1. Hold (R) and press (A) at the same time to open the "directory options"
+1. Hold (R) and press (A) at the same time to open the directory options
 1. Select "Open title manager"
 1. Press (A) to continue
 1. Press (A) on the `.tmd` file to select it, then select "TMD file options...", then select "Build CIA (standard)"
@@ -153,7 +153,7 @@ Insert the game cartridge you intend to dump into your device
 1. Navigate to the drive applicable to the type of title you wish to dump the contents of:
   + **User Installed `Title: [A:] SYSNAND SD`
   + **System Title: `[1:] SYSNAND CTRNAND`
-1. Hold (R) and press (A) at the same time to open the "directory options"
+1. Hold (R) and press (A) at the same time to open the directory options
 1. Select “Open title manager”
 1. Press (A) to continue
 1. Press (A) on the title you wish to dump the romfs/exefs from 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -138,10 +138,10 @@ Insert the game cartridge you intend to dump into your device
 ## Dumping a Title as a installable .CIA
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Navigate to the drive applicable to the type of title you wish to dump:
+1. Hover over the drive applicable to the type of title you wish to dump:
   + **User Installed Title**: `[A:] SYSNAND SD`
   + **System Title**: `[1:] SYSNAND CTRNAND`
-1. Hold (R) and press (A) at the same time to open the directory options
+1. Hold (R) and press (A) at the same time to open the drive options
 1. Select "Open title manager"
 1. Press (A) to continue
 1. Press (A) on the `.tmd` file to select it, then select "TMD file options...", then select "Build CIA (standard)"

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -105,7 +105,7 @@ This will only work if the Health & Safety injection was performed by GodMode9 (
 1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
 1. Press (A) to relock write permissions if prompted
 
-## Dumping a Game Cartridge
+## Dumping a Game Cartridge as a installable .CIA
 
 {% capture notice %}
 Insert the game cartridge you intend to dump into your device
@@ -122,50 +122,50 @@ Insert the game cartridge you intend to dump into your device
   + **NDS Game Cartridge:** Press (A) on `[TitleID].trim.nds` to select it, then select "Copy to 0:/gm9/out"
 1. Your installable `.cia` or non-installable `.nds` formatted file will be outputted to the `/gm9/out/` folder on your SD card
 
-## Dumping a Game Cartridges romfs/exefs
+## Dumping a Game Cartridge's contents
 
-1. Insert a game cartrige you wish to dump from
+1. Insert a game cartridge you wish to dump from
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Hover over "GAMECART ()"
-1. Press (A), wait (could take up to 20 seconds)
-1. Hover over the bigest file ending with `.3ds` and press (A)
+1. Navigate to `[C:] GAMECART`
+1. Hover over `[TitleID].trim.3ds` and press (A)
 1. Select "NCCH image options"
 1. Select "Mount image to drive"
 1. Press (A) to continue
-1. Hover over `exefs.bin`, hold (R) and press (A) to open "directory options", select "copy to 0:/gm9/out", do the same with `romfs.bin`
+1. Hover over the `exefs` directory, hold (R) and press (A) to open "directory options"
+1. Select "copy to 0:/gm9/out", do the same with the `romfs` directory
   + The dumped files will be in `/gm9/out`
 
-## Dumping a Title
+## Dumping a Title as a installable .CIA
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Hover over the drive applicable to the type of title you wish to dump:
+1. Navigate to the drive applicable to the type of title you wish to dump:
   + **User Installed Title**: `[A:] SYSNAND SD`
   + **System Title**: `[1:] SYSNAND CTRNAND`
-1. Hold (R) and press (A) at the same time to open the drive options
+1. Hold (R) and press (A) at the same time to open the "directory options"
 1. Select "Open title manager"
 1. Press (A) to continue
 1. Press (A) on the `.tmd` file to select it, then select "TMD file options...", then select "Build CIA (standard)"
 1. Your installable `.cia` formatted file will be outputted to the `/gm9/out/` folder on your SD card
 
-## Dumping a Titles romfs/exefs
+## Dumping a Title's contents
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Hover over the drive applicable to the type of title you wish to dump files for:
+1. Navigate to the drive applicable to the type of title you wish to dump the contents of:
   + **User Installed `Title: [A:] SYSNAND SD`
   + **System Title: `[1:] SYSNAND CTRNAND`
-1. Hold (R) and press (A) at the same time to open the drive options
-1. Select “open title manager”
+1. Hold (R) and press (A) at the same time to open the "directory options"
+1. Select “Open title manager”
 1. Press (A) to continue
 1. Press (A) on the title you wish to dump the romfs/exefs from 
-  + accent letters will be a `?`, like the e in pokemon
+  + Any non-alphanumeric characters will be a `?`, like the e in pokemon or Japanese characters
   + Titles will have the title ID before the name
-1. Press (A) on "open title folder"
-1. Then press (A) on the bigest file ending in `.app`(the file size is on the right of each file in gm9)
-  + `Byte` is smaller than `kb`, `kb` is smaller than `mb`, `mb` is smaller than `gb`. Example: 1.2 gb is bigger than 1.4 mb and so on
+1. Press (A) on "Open title folder"
+1. Then press (A) on the biggest file ending in `.app`
 1. Select (A) on "NCCH image options"
 1. Select (A) on "Mount image to drive"
 1. Press (A) to continue
-1. Hover over `exefs.bin`, hold (R) and press (A) to open "directory options", select "copy to 0:/gm9/out". Do the same with `romfs.bin`
+1. Hover over the `exefs` directory, hold (R) and press (A) to open "directory options"
+1. select "copy to 0:/gm9/out". Do the same with the `romfs.bin` directory
   + The dumped files will be in `/gm9/out`
 
 ## Converting a .3DS to .CIA

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -133,7 +133,7 @@ Insert the game cartridge you intend to dump into your device
 1. Press (A) to continue
 1. Hover over the `exefs` directory, hold (R) and press (A) to open the directory options
 1. Select "copy to 0:/gm9/out", do the same with the `romfs` directory
-  + The dumped files will be in `/gm9/out`
+  + The dumped files will be in `/gm9/out` on the sd card
 
 ## Dumping a Title as a installable .CIA
 
@@ -165,8 +165,8 @@ Insert the game cartridge you intend to dump into your device
 1. Select (A) on "Mount image to drive"
 1. Press (A) to continue
 1. Hover over the `exefs` directory, hold (R) and press (A) to open the directory options
-1. select "copy to 0:/gm9/out". Do the same with the `romfs` directory
-  + The dumped files will be in `/gm9/out`
+1. Select "copy to 0:/gm9/out". Do the same with the `romfs` directory
+  + The dumped files will be in `/gm9/out` on the sd card
 
 ## Converting a .3DS to .CIA
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -131,9 +131,9 @@ Insert the game cartridge you intend to dump into your device
 1. Select "NCCH image options"
 1. Select "Mount image to drive"
 1. Press (A) to continue
-1. Hover over the `exefs` directory, hold (R) and press (A) to open the directory options
-1. Select "copy to 0:/gm9/out", do the same with the `romfs` directory
-  + The dumped files will be in `/gm9/out` on the sd card
+1. Highlight the `exefs` and `romfs` directorys by holding (L) and selecting them with (A), then hold (R) and press (A) to open the directory options
+1. Select "copy to 0:/gm9/out"
+  + The dumped files will be in the `/gm9/out` folder on your SD card
 
 ## Dumping a Title as a installable .CIA
 
@@ -157,16 +157,16 @@ Insert the game cartridge you intend to dump into your device
 1. Select “Open title manager”
 1. Press (A) to continue
 1. Press (A) on the title you wish to dump the romfs/exefs from 
-  + Any non-alphanumeric characters will be a `?`, like the e in pokemon or Japanese characters
+  + Any non-alphanumeric characters will display as a `?`, like the e in Pokemon or Japanese characters
   + Titles will have the title ID before the name
 1. Press (A) on "Open title folder"
 1. Then press (A) on the biggest file ending in `.app`
 1. Select (A) on "NCCH image options"
 1. Select (A) on "Mount image to drive"
 1. Press (A) to continue
-1. Hover over the `exefs` directory, hold (R) and press (A) to open the directory options
-1. Select "copy to 0:/gm9/out". Do the same with the `romfs` directory
-  + The dumped files will be in `/gm9/out` on the sd card
+1. Highlight the `exefs` and `romfs` directorys by holding (L) and selecting both with (A), then hold (R) and press (A) to open the directory options
+1. Select "copy to 0:/gm9/out".
+  + The dumped files will be in the `/gm9/out` folder on your SD card
 
 ## Converting a .3DS to .CIA
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -105,7 +105,7 @@ This will only work if the Health & Safety injection was performed by GodMode9 (
 1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
 1. Press (A) to relock write permissions if prompted
 
-## Dumping a Game Cartridge as a installable .CIA
+## Dumping a Game Cartridge as an installable .CIA
 
 {% capture notice %}
 Insert the game cartridge you intend to dump into your device
@@ -131,11 +131,11 @@ Insert the game cartridge you intend to dump into your device
 1. Select "NCCH image options"
 1. Select "Mount image to drive"
 1. Press (A) to continue
-1. Highlight the `exefs` and `romfs` directorys by holding (L) and selecting them with (A), then hold (R) and press (A) to open the directory options
-1. Select "copy to 0:/gm9/out"
+1. Highlight the `exefs` and `romfs` directories by holding (L) and selecting them with (A), then hold (R) and press (A) to open the directory options
+1. Select "Copy to 0:/gm9/out"
   + The dumped files will be in the `/gm9/out` folder on your SD card
 
-## Dumping a Title as a installable .CIA
+## Dumping a Title as an installable .CIA
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Hover over the drive applicable to the type of title you wish to dump:
@@ -160,12 +160,13 @@ Insert the game cartridge you intend to dump into your device
   + Any non-alphanumeric characters will display as a `?`, like the e in Pokemon or Japanese characters
   + Titles will have the title ID before the name
 1. Press (A) on "Open title folder"
-1. Then press (A) on the biggest file ending in `.app`
+1. Press (A) on the biggest file ending in `.app`
 1. Select (A) on "NCCH image options"
 1. Select (A) on "Mount image to drive"
 1. Press (A) to continue
-1. Highlight the `exefs` and `romfs` directorys by holding (L) and selecting both with (A), then hold (R) and press (A) to open the directory options
-1. Select "copy to 0:/gm9/out".
+1. Highlight the `exefs` and `romfs` directories by holding (L) and selecting both with (A)
+1. Hold (R) and press (A) to open the directory options
+1. Select "Copy to 0:/gm9/out".
   + The dumped files will be in the `/gm9/out` folder on your SD card
 
 ## Converting a .3DS to .CIA


### PR DESCRIPTION
This pull request adds how to dump romfs and exefs from installed titles and gamecarts. this is to give people a direct guide to link to when someone asks how to dump them for whatever reason (be it making a mod for a game, or something else). It could also be used for dumping other files from titles and gamecarts for whatever reason.

I have seen many people now come into the assistance channels asking how to dump the romfs and exefs. or this just coming up in conversation and asking how to do it