### PR TITLE
Fixing linktext for ntrboot_flasher_nds

### DIFF
--- a/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
@@ -17,7 +17,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 * Your ntrboot compatible flashcart
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`boot9strap-1.3-ntr.zip`; not the devkit file)*
-* The latest release of [ds_ntrboot_flasher](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest)
+* The latest release of [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest)
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(nds).txt
+++ b/_pages/en_US/flashing-ntrboot-(nds).txt
@@ -20,7 +20,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
   + **The source NDS / NDSL**: the Nintendo DS or Nintendo DS Lite which is compatible with your flashcart
   + **The target 3DS**: the 3DS family device on stock firmware
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`boot9strap-1.3-ntr.zip`; not the `devkit` file)*
-* The latest release of [ds_ntrboot_flasher](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest)
+* The latest release of [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest)
 
 ### Instructions
 


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->
ds_ntrboot_flasher is actually the outdated flasher by ntrteam, might be confusing.

