### PR TITLE
#1870 typos

### DIFF
--- a/_pages/en_US/dumping-titles-and-game-cartridges.txt
+++ b/_pages/en_US/dumping-titles-and-game-cartridges.txt
@@ -62,8 +62,6 @@ This will only work for 3DS games; it is not possible to install an NDS game car
 This should only be used if [Installing a Game Cartridge Directly to the System](#installing-a-game-cartridge-directly-to-the-system) does not work.
 {: .notice--info}
 
-<div class="notice--info">{{ notice | markdownify }}</div>
-
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Navigate to `[C:] GAMECART`
 1. Press (A) on `[TitleID].trim.3ds` to select it, then select "NCSD image options...", then select "Build CIA from file"
@@ -90,7 +88,7 @@ This allows dumping of both System- and User-installed digital titles, such as o
 The game will be outputted to the `/gm9/out/` folder on your SD card with the name `<TitleID>.gbavc.sav`.
 {: .notice--info}
 
-To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by hovering over `[A:] SYSNAND SD`, holding (R) and pressing (A) at the same time, then selecting "Search for titles".
+To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by pressing (Home) to bring up the action menu, selecting `Title manager`, and selecting `[A:] SD CARD`.
 {: .notice--info}
 
 1. Do the following process for each GBA VC game that you want to backup the save for:
@@ -107,7 +105,7 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 
 ## Restore GBA VC Saves
 
-To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by hovering over `[A:] SYSNAND SD`, holding (R) and pressing (A) at the same time, then selecting "Search for titles".
+To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by pressing (Home) to bring up the action menu, selecting `Title manager`, and selecting `[A:] SD CARD`.
 {: .notice--info}
 
 1. Do the following process for each GBA VC game that you want to restore the save for:


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

I screwed up.

In this PR:
- Dumping `.cia` guide accidentally mentions that 3DS games be dumped to `.3ds` and NDS games dumped to `.nds` etc. Message is removed
- GBA VC Backup/Restore still uses older method of identifying Title ID, so that has been changed to reflect Title manager as well.

Please provide feedback.