### PR TITLE
Use GM9Megascript to dump boot9

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -132,16 +132,17 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + If you get an error, make sure that you have at least 1.3GB of free space on your SD card
 1. Press (A) to continue
 1. Press (B) to return to the main menu
+1. Select "Dump Options"
+1. Select "Dump Boot9.bin & Boot11.bin"
+1. When prompted, press (A) to proceed
+1. Press (A) to continue
+1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted
-1. Navigate to `[M:] MEMORY VIRTUAL`
-1. Press (A) on `boot9.bin` to select it
-1. Select "Copy to 0:/gm9/out"
-1. Press (A) to continue
 1. Press (Home) to bring up the action menu
 1. Select "Poweroff system" to power off your device
 1. Insert your SD card into your computer
-1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, `essential.exefs`, and `boot9.bin` from the `/gm9/out/` folder on your SD card to a safe location on your computer
+1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, `essential.exefs`, `<serialnumber>_boot9_###.bin`, and `<serialnumber>_boot11_###.bin` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

Fixes #1880, fixes #1871.

The GM9Megascript has the function to dump `boot9.bin` and `boot11.bin` automatically, which negates the need for going into `MEMORY VIRTUAL` manually. This should be used instead for easier dumping of said files.

The initial PR, which was since abandoned, suggests removing line 163. Personally I think it should be there, so I left it unchanged for now. Please let me know if that should be changed.