### PR TITLE
ctrtransfer: add ext mem mode warning

### DIFF
--- a/_pages/en_US/ctrtransfer.txt
+++ b/_pages/en_US/ctrtransfer.txt
@@ -15,6 +15,9 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
 You MUST have already installed Luma3DS and boot9strap to use this.
 {: .notice--danger}
 
+Performing a CTRTransfer may break extended memory mode games (Monster Hunter, Super Smash Bros, Pokemon Sun/Moon) on Old 3DS/2DS devices. If this occurs, you will need to format the device (using TinyFormat or System Settings) to fix the issue.
+{: .notice--warning}
+
 ### What You Need
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -27,6 +27,9 @@ Region changing using CTRTransfer (which this method uses) seems to cause reboot
 You MUST have already installed Luma3DS and boot9strap to use this.
 {: .notice--danger}
 
+Performing a CTRTransfer may break extended memory mode games (Monster Hunter, Super Smash Bros, Pokemon Sun/Moon) on Old 3DS/2DS devices. If this occurs, you will need to format the device (using TinyFormat or System Settings) to fix the issue.
+{: .notice--warning}
+
 ### What You Need
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
@@ -158,6 +161,3 @@ If script found no user tickets told you to skip this section, then skip this se
 1. Press (Start) to reboot your device
 
 ___
-
-Old 3DSs and 2DSs may need to format (using TinyFormat or the System Settings) to play extended memory mode games (such as Monster Hunter, Super Smash Bros, or Pokemon Sun/Moon).
-{: .notice--info}


### PR DESCRIPTION
Also makes warning in region-changing consistent and moves it to the top of the page (where it is more likely to be seen). Fixes #1876.
