### PR TITLE
Troubleshooting: Complete overhaul

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -67,7 +67,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set your DNS settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#system-update-error-after-installing-cfw)
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#unable-to-update-device)
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/installing-boot9strap-(browser).txt
+++ b/_pages/en_US/installing-boot9strap-(browser).txt
@@ -36,7 +36,7 @@ new-browserhax-xl/old-browserhax-xl (when combined with universal-otherapp) is c
 1. On the HOME Menu, press the Left and Right shoulder buttons together to open the camera
   + If you are unable to open the camera, open the Internet Browser and manually type the URL instead (`https://zoogie.github.io/web/nbhax`)
 1. Tap the QR code button and scan [this QR code](http://api.qrserver.com/v1/create-qr-code/?color=000000&bgcolor=FFFFFF&data=https%3A%2F%2Fzoogie.github.io%2Fweb%2Fnbhax&qzone=1&margin=0&size=400x400&ecc=L)
-  + If you get an error, [follow this troubleshooting guide](troubleshooting#a-browser-based-exploit-is-not-working)
+  + If you get an error, [follow this troubleshooting guide](troubleshooting#installing-boot9strap-browser)
 1. If the exploit was successful, you will have booted into SafeB9SInstaller
 
 #### Section III - Installing boot9strap

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -2,164 +2,79 @@
 title: "Troubleshooting"
 ---
 
-{% include toc title="Table of Contents" %}
+{% include toc title="Table of Contents"%}
 
-### Required Reading
+This page offers troubleshooting advice for commonly encountered issues. If you are unable to solve your issue with the advice on this page, please join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and describe your issue, including what you have already tried.
 
-If you are unable to boot your device, please look for the section relevant to you and follow the instructions.
+# Page-related issues on this guide
 
-If you still cannot solve your issue and need to reach out for help, please paste the contents of all relevant .log files from the root of your SD card into a [Gist](https://gist.github.com/), then come for help prepared with a detailed description of your problem and what you've tried.
+---
 
-Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding (Start) on boot will display a "chainloader menu" where you will have to use the D-Pad and the (A) button to select "GodMode9" for these instructions. 
+## Issues with SafeB9SInstaller
 
-To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+### SigHaxed FIRM was not installed! Check lower screen for more info.
 
-## DSi / DS functionality is broken after completing the guide
+#### SigHaxed FIRM - File not found
 
-### What You Need
+You are missing `boot9strap.firm` and `boot9strap.firm.sha` from the `boot9strap` folder, or the `boot9strap` folder is misnamed. Download the latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest), and place `boot9strap.firm` and `boot9strap.firm.sha` in the `boot9strap` folder.. Make sure to download the correct file (`boot9strap-1.3.zip`, not devkit, not ntr).
 
-* The latest release of [TWLFix-CFW](https://github.com/MechanicalDragon0687/TWLFix-CFW/releases/latest) *(the .3dsx file)*
+#### Secret Sector - File not found
 
-### Instructions
+You are missing `secret_sector.firm` from the `boot9strap` folder, or the `boot9strap` folder is misnamed. Download [secret_sector.bin](magnet:?xt=urn:btih:15a3c97acf17d67af98ae8657cc66820cc58f655&dn=secret_sector.bin&tr=udp%3A%2F%2F9.rarbg.to%3A2710%2Fannounce&tr=udp%3A%2F%2Fbt.xxx-tracker.com%3A2710%2Fannounce&tr=udp%3A%2F%2Fexodus.desync.com%3A6969%2Fannounce&tr=udp%3A%2F%2Fmgtracker.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fopen.demonii.si%3A1337%2Fannounce&tr=udp%3A%2F%2Fpublic.popcorn-tracker.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fthetracker.org%3A80%2Fannounce&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.cypherpunks.ru%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.ds.is%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.internetwarriors.net%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.mg64.net%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.open-internet.nl%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.port443.xyz%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.qt.is%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.torrent.eu.org%3A451%2Fannounce&tr=udp%3A%2F%2Ftracker.vanitycore.co%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker-2.msm8916.com%3A6969%2Fannounce) using a torrent client, and place it in the `boot9strap` folder.
 
-#### Section I - Prep Work
+#### Something else
 
-1. Power off your device
-1. Insert your SD card into your computer
-1. Create a folder named `3ds` on the root of your SD card if it does not already exist
-1. Copy `TWLFix-CFW.3dsx` to the `/3ds/` folder on your SD card
-1. Reinsert your SD card into your device
+Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance, and describe the message that you see.
 
-#### Section II - Fixing TWL
+---
 
-1. Open the Homebrew Launcher
-1. Launch TWLFix-CFW from the list of homebrew
-1. Press (A) to uninstall the broken TWL titles
-1. Press (Start) to reboot the device
-1. Perform a System Update by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
-  + The update will see that the essential TWL titles have been uninstalled, and will redownload and reinstall them
-1. Once the update is complete, tap "OK" to reboot the device 
+## Installing boot9strap (Browser)
 
-## Cannot inject H&S on Gateway downgraded device
+### Red and white screen after running Browserhax
 
-This is caused by Gateway implementing a very shoddy downgrade method which leaves two versions of each app on the system. One of them is unused, but it confuses the H&S inject system, causing it to inject into the wrong one.
+Your device likely already has custom firmware. You should [check for CFW](checking-for-cfw).
 
-1. Power off your device
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Navigate to `[1:] SYSNAND CTRNAND` -> `title` -> `00040010`
-1. Navigate to the folder for your device and region:
-  + **Old 3DS or Old 2DS EUR**: `00022300` -> `content`
-  + **Old 3DS or Old 2DS JPN**: `00020300` -> `content`
-  + **Old 3DS or Old 2DS USA**: `00021300` -> `content`
-  + **New 3DS or New 2DS EUR**: `20022300` -> `content`
-  + **New 3DS or New 2DS JPN**: `20020300` -> `content`
-  + **New 3DS or New 2DS USA**: `20021300` -> `content`
-1. Notice that there are two sets of app and tmd files, one set with uppercase extensions (`.TMD` and `.APP`), and one set with lowercase extensions (`.tmd` and `.app`)
-1. While holding the (R) trigger, press (Y) to create a new directory
-1. Press (A) to confirm the name `newdir` (it does not matter what the folder is called)
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-1. Press (B) to decline relocking write permissions if prompted
-1. Press the (L) trigger on each of the uppercase extension files (`.TMD` and `.APP`) to mark them
-1. Press (Y) to copy the files
-1. Navigate to `newdir`
-1. Press (Y) to paste the files
-1. Select "Move path(s)"
-1. The uppercase extension files will have been moved to the `newdir` directory
-1. Press (Start) to reboot your device
-1. Retry the H&S injection
-1. If this still doesn't work, move the uppercase extension files back to the `content` folder, then move the lowercase extension files to the `newdir` folder, then retry the H&S injection
+### Green screen after running Browserhax
 
-## A browser based exploit is not working
+Force power off your device by holding the POWER button for at least 15 seconds, then try again.
 
-Browser based exploits (such as browserhax or 2xrsa) are often unstable and crash frequently, but they can sometimes be fixed by doing the following steps.
+### "An error has occurred, forcing the software to close..."
 
 1. Launch the browser, then launch the browser settings
 1. Scroll to the bottom and Initialize Savedata (it also may be called Clear All Save Data)
 1. Try the exploit again
 
-## Black screen on SysNAND boot
+This error could also indicate an issue with your `arm11code.bin` file.
 
-1. Try booting with your SD card out, and then reinserting it after booting
-    1. Power off your device
-    1. Remove your SD card from your device
-    1. Power on your device
-    1. When the home menu appears, reinsert your SD card into your device
-    1. If this worked, you should clear Home Menu's extdata by following these instructions:
-        1. Power off your device
-        1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-        1. Press (Home) to bring up the action menu
-        1. Select "Scripts..."
-        1. Select "GM9Megascript"
-        1. Select "Scripts from Plailect's Guide"
-        1. Select "Remove extdata"
-        1. Press (A) to continue
-        1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-        1. Press (A) to continue
-        1. Press (B) to return to the main menu
-        1. Select "Exit"
-        1. Press (A) to relock write permissions if prompted
-        1. Press (Start) to reboot your device
-1. Try booting without any cartridges inserted (including flashcarts)
-1. If you have a hardmod and a NAND backup, flash the backup back to SysNAND
-1. Try booting into recovery mode and updating your system
-    1. Power off your device
-    1. Hold (L) + (R) + (A) + (Up)
-    1. Power on your device
-    1. If you enter safe mode, update your device
-1. Your device may be bricked. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+### "An error has occurred. Hold down the POWER button to turn off the power..."
 
-## Clear Home Menu extdata
+The file `arm11code.bin` is missing, misplaced, or misnamed. Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest), rename it to `arm11code.bin`, and place it on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
 
-1. Power off your device
-1. Insert your SD card into your computer
-1. Navigate to the `/Nintendo 3DS/<32-character-id>/<32-character-id>/extdata/00000000/` folder on your SD card
-1. Delete the extdata file corresponding to your region:
-  + **EUR Region**: `00000098`
-  + **JPN Region**: `00000082`
-  + **USA Region**: `0000008f`
-  + **CHN Region**: `000000A1`
-  + **KOR Region**: `000000A9`
-  + **TWN Region**: `000000B1`
-1. Reinsert your SD card into your device
+---
 
-## Black screen on SysNAND boot after Installing boot9strap
+## Installing boot9strap (Soundhax)
 
-1. Ensure you have a working payload
-    1. Check for the existence of `boot.firm` in the root of your SD card.
-1. Try resetting Luma's config and fix options
-    1. Delete `/luma/config.bin` from your SD card
-    1. Set your options when it boots
-1. Test booting GodMode9
-    1. On Luma3DS, hold (Start) on boot
-1. Try deleting home menu's extdata by following these instructions:
-    1. Power off your device
-    1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-    1. Press (Home) to bring up the action menu
-    1. Select "Scripts..."
-    1. Select "GM9Megascript"
-    1. Select "Scripts from Plailect's Guide"
-    1. Select "Remove extdata"
-    1. Press (A) to continue
-    1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-    1. Press (A) to continue
-    1. Press (B) to return to the main menu
-    1. Select "Exit"
-    1. Press (A) to relock write permissions if prompted
-    1. Press (Start) to reboot your device
-1. Try booting without any cartridges inserted (including flashcarts)
-1. If you previously downgraded with Gateway, ensure that you are using the latest Luma3DS version
-1. Try following [CTRTransfer](ctrtransfer)
-1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+### Red and white screen after running Soundhax
 
-## Blue screen on boot (bootrom error)
+If your device is on system version 9.4.0, 9.5.0, or 9.6.0, you may be encountering a bug with universal-otherapp. Follow [Homebrew Launcher (Soundhax)](homebrew-launcher-(soundhax)) instead.
 
-1. Your device is bricked
-1. You will need to get an ntrboot-comptible flashcart (one of the ones on [this list](ntrboot) or a [hardmod](https://gbatemp.net/threads/414498/), or repair / replace your device
-1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+If your device is not on those firmwares, it likely indicates that you already have custom firmware. You should [check for CFW](checking-for-cfw).
 
-## System update error after installing CFW
+### "An error has occurred, forcing the software to close..."
 
- Occasionally, updates may fail to install after installing CFW. To fix this, reboot your device after each step of this section, then try updating again.
+There is an issue with your `otherapp.bin` file (it is missing, misplaced, or corrupted). Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) and place it on the root of your SD card.
+
+### "Could not play"
+
+You have the wrong Soundhax file for your device and region, or your device is incompatible with Soundhax. In the latter case, you should update your device to the latest version and follow [Installing boot9strap (Browser)](installing-boot9strap-(browser)).
+
+---
+
+## Finalizing Setup
+
+### Unable to update device
+
+The steps below can be attempted in any order, but are listed from easiest to hardest to perform.
 
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
@@ -170,3 +85,119 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. Nintendo servers may be down; Try again later
 1. If you still get an error, [follow CTRTransfer](ctrtransfer), then try again
 1. For support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+
+### Unable to enter Rosalina due to broken button(s)
+
+Download this [alternate config.bin](https://cdn.discordapp.com/attachments/196635695958196224/733384123003175074/config.bin) and place it in `/luma/`. This will change the Rosalina key combination to (Y) + (B).
+
+### "An exception occurred" after trying to launch Homebrew Launcher via Download Play
+
+There is an issue with your `boot.firm` file (it is missing, misplaced, or corrupted). Download the latest release of [the Homebrew Launcher](https://github.com/fincs/new-hbmenu/releases/latest) and place `boot.3dsx` on the root of your SD card, replacing any existing file. Make sure you are extracting the ZIP file with any tool other than WinRAR, as it is known to cause issues with 3DS-related files.
+
+### "Scripts directory not found" in GodMode9
+
+You did not copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card. Download the latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) and place the `gm9` folder on the root of your SD card, merging it with the existing one.
+
+### `essentials.exefs` missing from `/gm9/out/`
+
+Your device had custom firmware in the past, so you were not automatically prompted to make a backup. Make a backup manually:
+
+1. Reinsert your SD card into your device
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Navigate to 	`[S:] SYSNAND VIRTUAL`
+1. Select `essentials.exefs`, then `Copy to 0:/gm9/out/`
+1. You should now have `essentials.exefs` in `/gm9/out/`
+
+---
+
+# Boot-related issues on modded devices
+
+The steps detailed here generally assume that your device has a modern custom firmware setup (boot9strap + Luma3DS 8.0 or greater). If your console is running an older homebrew setup (for example, something based on arm9loaderhax or menuhax), you should update your setup before trying these instructions.
+{: .notice--info}
+
+## My device gets stuck on a black screen, with a static blue light
+
+The steps below can be attempted in any order, but are listed from least to most time-consuming.
+
+1. Power off your device, eject the game cartridge if inserted, power on your device, then wait up to ten minutes. If your device boots within ten minutes, the issue has been fixed and is unlikely to reoccur
+1. Rename the `Nintendo 3DS` folder on your SD card to `Nintendo 3DS_BACKUP`, then attempt to boot. If your device successfully boots, there is some issue within your `Nintendo 3DS` folder. Try clearing home menu extdata:
+	+ Navigate to `/Nintendo 3DS/<ID0>/<ID1>/extdata/00000000/`
+	+ Delete the extdata file corresponding to your region: 
+		+ **EUR Region**: `00000098`
+		+ **JPN Region**: `00000082`
+		+ **USA Region**: `0000008f`
+		+ **CHN Region**: `000000A1`
+		+ **KOR Region**: `000000A9`
+		+ **TWN Region**: `000000B1`
+1. Ensure that your device does not have ARM11 exception handlers disabled:
+	+ Power off your device
+	+ Hold (Select)
+	+ Power on your device, while still holding (Select)
+	+ If the "Disable ARM11 exception handlers" box is checked, uncheck it
+	+ If your device now boots to the "An exception occured" screen, follow [My device boots to an error screen](troubleshooting#my-device-boots-to-an-error-screen)
+1. Try booting into recovery mode and updating your system:
+	+ Power off your device
+	+ Hold (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A)
+	+ Power on your device
+	+ If you were successful, the device will boot to an "update your system" screen
+1. Follow the [CTRTransfer](ctrtransfer) guide
+1. Ask for help at [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+
+---
+
+## My device boots to an error screen
+
+### "An error has occurred: Failed to apply 1 FIRM patch(es)" or "An exception has occurred -- Current process: pm"
+
+Your Luma3DS version is outdated. Download the latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) and place `boot.firm` on the root of your SD card, replacing any existing file. Make sure you are extracting the ZIP file with any tool other than WinRAR, as it is known to cause issues with 3DS-related files.
+
+### "An error has occurred. Hold down the POWER button to turn off the power..."
+
+ARM11 exception handlers are disabled, or custom firmware is not installed. Try enabling ARM11 exception handlers:
+	+ Power off your device
+	+ Hold (Select)
+	+ Power on your device, while still holding (Select)
+	+ If the "Disable ARM11 exception handlers" box is checked, uncheck it
+
+### Some other error
+
+Please take a photo of the error and [join Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+
+---
+
+## My device gets stuck on a black light, and the blue light turns off
+
+There is an issue with your `boot.firm` file (it is missing, misplaced, or corrupted). Download the [latest release of Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) and place `boot.firm` on the root of your SD card, replacing any existing file. Make sure you are extracting the ZIP file with any tool other than WinRAR, as it is known to cause issues with 3DS-related files.
+
+If you hear a "popping sound", potentially accompanied with the backlight turning on for a split second, there is a hardware issue with your device (such as a disconnected backlight cable). You may be able to get your device to boot by holding it at certain angles.
+
+## My device gets stuck on a blue "Bootrom Error" screen
+
+Your device is likely hard-bricked. You will need to buy an ntrboot flashcart to reinstall boot9strap in order to attempt to fix your device. This may also indicate a hardware issue which cannot be fixed. In any case, [join Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+
+---
+
+# Functionality-related issues on modded devices
+
+## DSi / DS functionality is broken, or has been replaced with Flipnote Studio
+
+1. Download the latest release of [TWLFix-CFW](https://github.com/MechanicalDragon0687/TWLFix-CFW/releases/latest) (the `.3dsx` file)
+1. Power off your device
+1. Create a folder named `3ds` on the root of your SD card if it does not already exist
+1. Copy `TWLFix-CFW.3dsx` to the `/3ds/` folder on your SD card
+1. Reinsert your SD card into your device
+1. Open the Homebrew Launcher
+1. Launch TWLFix-CFW from the list of homebrew
+1. Press (A) to uninstall the broken TWL titles
+1. Press (Start) to reboot the device
+1. Perform a System Update by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
+  + The update will see that the essential TWL titles have been uninstalled, and will redownload and reinstall them
+1. Once the update is complete, tap "OK" to reboot the device 
+
+## GBA Virtual Console functionality is broken
+
+Your device is running Luma 6.6 or older from arm9loaderhax. You should follow [A9LH to B9S](a9lh-to-b9s) to update your device to a modern custom firmware environment.
+
+## Extended memory mode games are broken
+
+You will need to system format your device to fix this issue.


### PR DESCRIPTION
This PR completely overhauls the troubleshooting page, offering advice for issues that are commonly encountered, in particular:

- Use of more human wording in troubleshooting (not always step-by-step instructions)
- Troubleshooting for issues on commonly used main guide paths (Browser, Soundhax, Finalizing Setup)
- Removal of troubleshooting for very rarely seen issues ("cannot inject H&S on Gateway-downgrade devices)
- Revision of most existing pieces of troubleshooting (e.g. "Black screen on SysNAND boot")

Potential issues with this PR:

- The table of contents is *incredibly* long, spanning almost two screen sizes in full screen and one and a half at half width. 
- Issues may not be totally comprehensive, or some issues may be too specific.
- Troubleshooting is not currently well-linked on the rest of the guide, and this PR does not change that. This page should be made more prominent so that it can actually get some use.
- Links to the correct headers have been changed in two places (one in `Installing boot9strap (Browser)`, and one in `Finalizing Setup`). This may not account for every link to the troubleshooting guide.