### PR TITLE
Add kramdown-parser-gfm to Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 gem 'jekyll-redirect-from'
+gem 'kramdown-parser-gfm'
 gemspec


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

This PR adds `kramdown-parser-gfm` to Gemfile. This doesn't really have anything to do with the page, but for local testing, it keeps failing to build the site without it, and it isn't really messing with the site either way, so why not? 

Admittedly this is more of an annoyance thing than anything else, but I assume other people are having this issue as well when offline testing.