### PR TITLE
Update installing boot9strap (browser) to more correctly reflect the on-screen information

### DIFF
--- a/_pages/en_US/installing-boot9strap-(browser).txt
+++ b/_pages/en_US/installing-boot9strap-(browser).txt
@@ -41,8 +41,8 @@ new-browserhax-xl/old-browserhax-xl (when combined with universal-otherapp) is c
 
 #### Section III - Installing boot9strap
 
-1. Wait for all safety checks to complete
-1. When prompted, input the key combo given to install boot9strap
+1. Wait for all checks to complete
+1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it has completed, press (A) to reboot your device
 
 #### Section IV - Configuring Luma3DS

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -48,10 +48,10 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 
 #### Section III - Installing boot9strap
 
-1. Wait for all safety checks to complete
+1. Wait for all checks to complete
 1. Remove the magnet from your device
   + On old 2DS, you should instead disable the sleep mode switch
-1. When prompted, input the key combo given to install boot9strap
+1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it has completed, force your device to power off by holding down the power button
   + Your device will only boot to the SafeB9SInstaller screen until the next section is completed
 

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -55,8 +55,8 @@ Soundhax (when combined with universal-otherapp) is compatible with versions 1.0
 
 #### Section III - Installing boot9strap
 
-1. Wait for all safety checks to complete
-1. When prompted, input the key combo given to install boot9strap
+1. Wait for all checks to complete
+1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it has completed, press (A) to reboot your device
 
 #### Section IV - Configuring Luma3DS


### PR DESCRIPTION

After some complains from a dyslexic user, I decided to make 2 pretty minor changes

Section 3, step 1 - changed "all safety checks" to "all checks" - safeb9sinstaller just calls them "checks", so the word safety there was unneeded
Section 3, step 2 - changed "key combo given to install..." to "key combo given on the top screen to install..." - this specifically calls out where the combo will be given, to prevent users from looking at the bottom screen when the combo is on the top.

no i totally didnt forget to make this pr for like 2 weeks after making the changes shhh
