### PR TITLE
Update link so that it displays properly in Spanish

### DIFF
--- a/_pages/es_ES/installing-boot9strap-(browser).txt
+++ b/_pages/es_ES/installing-boot9strap-(browser).txt
@@ -11,8 +11,7 @@ new-browserhax-xl/old-browserhax-xl (when combined with universal-otherapp) is c
 ### Qué necesitas
 
 * The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest)
-* La última versión de [SafeB9SInstaller]
-(https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* La última versión de [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`boot9strap-1.3.zip`; not the `devkit` file, not the `ntr` file)*
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) 
 


### PR DESCRIPTION
Update link so that it displays properly on the "Install boot9strap (Browser)" page for the Spanish guide as it would not show as a link.