### PR TITLE
add dumping essential.exefs to finalize

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -136,6 +136,9 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Select "Dump Boot9.bin & Boot11.bin"
 1. When prompted, press (A) to proceed
 1. Press (A) to continue
+1. Select "Dump essential.exefs"
+1. When prompted, press (A) to proceed
+1. Press (A) to continue
 1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -136,9 +136,6 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Select "Dump Boot9.bin & Boot11.bin"
 1. When prompted, press (A) to proceed
 1. Press (A) to continue
-1. Select "Dump essential.exefs"
-1. When prompted, press (A) to proceed
-1. Press (A) to continue
 1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -142,7 +142,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Navigate to `[S:] SYSNAND VIRTUAL`
 1. Press (A) on `essential.exefs` to select it
 1. Select "Copy to 0:/gm9/out"
-  + If prompted that "Destination already exists", press (A) on "Overwrite file(s)"
+  + If you see "Destination already exists", press (A) on "Overwrite file(s)"
 1. Press (A) to continue
 1. Press (Home) to bring up the action menu
 1. Select "Poweroff system" to power off your device

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -139,6 +139,11 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted
+1. Navigate to `[S:] SYSNAND VIRTUAL`
+1. Press (A) on `essential.exefs` to select it
+1. Select "Copy to 0:/gm9/out"
+  + If prompted that "Destination already exists", press (A) on "Overwrite file(s)"
+1. Press (A) to continue
 1. Press (Home) to bring up the action menu
 1. Select "Poweroff system" to power off your device
 1. Insert your SD card into your computer


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

By request of @lilyuwuu `essential.exefs` is now dumped during Finalizing Setup. `.noexefs` is no more.

GM9Megascript has everything.