### PR TITLE
"All versions" list is directing to wrong ntrboot page in Get Started

### DIFF
--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -61,5 +61,5 @@ The letter and number after the system version (for example, 11.14.0-**46U**) is
 
 A number of methods that work on all versions are available, but require additional hardware. If possible, you should follow one of the software methods listed above instead.
 
-1. [Installing boot9strap (ntrboot)](installing-boot9strap-(ntrboot)) - requires compatible DS flashcart
+1. [ntrboot](ntrboot) - requires compatible DS flashcart
 1. [Installing boot9strap (Hardmod)](installing-boot9strap-(hardmod)) - requires soldering


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

The "All versions" list in "Get Started" is redirecting to "Installing boot9strap (ntrboot)" and not "ntrboot". We can't be skipping steps here, can we?

Now it's directing to ntrboot.