### PR TITLE
seedminer returns from the grave (11.15 guide update)

### DIFF
--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -4,9 +4,6 @@ title: "BannerBomb3"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page (such as broken shoulder buttons).
-{: .notice--warning}
-
 ### Required Reading
 
 To dump system DSiWare, we exploit a flaw in the DSiWare Data Management window of the Settings application.

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -24,7 +24,7 @@ While we believe that custom firmware is safe for online use, there have been on
 
 ### Version Table
 
-The letter and number after the system version (for example, 11.14.0-**46U**) is not relevant in this version table.
+The letter and number after the system version (for example, 11.15.0-**47U**) is not relevant in this version table.
 
 <table>
   <colgroup>
@@ -47,12 +47,12 @@ The letter and number after the system version (for example, 11.14.0-**46U**) is
     </tr>
 	<tr>
       <td style="text-align: center; font-weight: bold;">11.4.0</td>
-      <td style="text-align: center; font-weight: bold;">11.13.0</td>
+      <td style="text-align: center; font-weight: bold;">11.14.0</td>
       <td style="text-align: center; font-weight: bold;">Update your 3DS to the latest version through System Settings</td>
     </tr>
     <tr>
-      <td style="text-align: center; font-weight: bold;" colspan="2">11.14.0 (latest version)</td>
-      <td style="text-align: center; font-weight: bold;"><a href="installing-boot9strap-(browser)">Installing boot9strap (Browser)</a></td>
+      <td style="text-align: center; font-weight: bold;" colspan="2">11.15.0 (latest version)</td>
+      <td style="text-align: center; font-weight: bold;"><a href="seedminer">Seedminer</a></td>
     </tr>
   </tbody>
 </table>

--- a/_pages/en_US/homebrew-launcher-(pichaxx).txt
+++ b/_pages/en_US/homebrew-launcher-(pichaxx).txt
@@ -4,9 +4,6 @@ title: "Homebrew Launcher (PicHaxx)"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page (such as broken shoulder buttons).
-{: .notice--warning}
-
 ### Required Reading
 
 This method of using Seedminer for further exploitation uses your `movable.sed` file to gain access to the Homebrew Launcher using the PicHaxx exploit for the purposes of injecting an exploitable DSiWare title into the DS Download Play application. This method requires you to already own (or download) the free "Pokemon Picross" game from the eShop.

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -4,9 +4,6 @@ title: "Installing Boot9strap (Fredtool)"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page (such as broken shoulder buttons).
-{: .notice--warning}
-
 ### Required Reading
 
 This method of using Seedminer for further exploitation uses your `movable.sed` file to decrypt any DSiWare title for the purposes of injecting an exploitable DSiWare title into the DS Internet Settings application. This requires you to have a DSiWare backup, for example from BannerBomb or the DSiWare Dumper tool.

--- a/_pages/en_US/installing-boot9strap-(frogtool).txt
+++ b/_pages/en_US/installing-boot9strap-(frogtool).txt
@@ -4,9 +4,6 @@ title: "Installing Boot9strap (Frogtool)"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page (such as broken shoulder buttons).
-{: .notice--warning}
-
 ### Required Reading
 
 We will now use our Homebrew Launcher access to run the Frogtool utility in order to inject the exploitable Japanese version of the "Flipnote Studio" title, which we then use to run b9sTool and install boot9strap.

--- a/_pages/en_US/installing-boot9strap-(pichaxx).txt
+++ b/_pages/en_US/installing-boot9strap-(pichaxx).txt
@@ -4,9 +4,6 @@ title: "Installing boot9strap (PicHaxx)"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page (such as broken shoulder buttons).
-{: .notice--warning}
-
 ### Required Reading
 
 This method of using Seedminer for further exploitation uses your `movable.sed` file to write a custom save file for Pokémon Picross, which can then be used with universal-otherapp to run SafeB9SInstaller.

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -4,9 +4,6 @@ title: "Installing boot9strap (USM)"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page.
-{: .notice--warning}
-
 ### Required Reading
 
 In order to exploit the SAFE_MODE firmware of our system, we need to inject an exploited WiFi profile.

--- a/_pages/en_US/seedminer.txt
+++ b/_pages/en_US/seedminer.txt
@@ -4,9 +4,6 @@ title: "Seedminer"
 
 {% include toc title="Table of Contents" %}
 
-Seedminer-based methods have been replaced by easier, safer methods. Please return to [Get Started](get-started) unless you have a legitimate reason to follow this page (such as broken shoulder buttons).
-{: .notice--warning}
-
 ### Required Reading
 
 To install boot9strap on your device, we derive your device's unique encryption key.

--- a/_pages/en_US/site-navigation.txt
+++ b/_pages/en_US/site-navigation.txt
@@ -9,7 +9,7 @@ sitemap: false
 
 + [Finalizing Setup](finalizing-setup)
 + [Installing boot9strap (Soundhax)](installing-boot9strap-(soundhax))
-+ [Installing boot9strap (Browser)](installing-boot9strap-(browser))
++ [Seedminer](seedminer)
 
 {% endcapture %}
 <div class="notice--info">{{ notice-1 | markdownify }}</div>


### PR DESCRIPTION
Updates guide to support 11.15. In particular:
- Removal of browserhax as main guide path -- not completely removed/stubbed yet.
- Removal of Seedminer out-of-date warning.
- Addition of Seedminer to get-started and site-nav recommended.
