### PR TITLE
restoring-cfw: add ctrnand luma

### DIFF
--- a/_pages/en_US/restoring-updating-cfw.txt
+++ b/_pages/en_US/restoring-updating-cfw.txt
@@ -10,6 +10,7 @@ This page prepares consoles with an existing modern boot9strap installation for 
 
 ### What You Need
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+* The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
 
 ### Instructions
 
@@ -18,6 +19,8 @@ This page prepares consoles with an existing modern boot9strap installation for 
 1. Insert your SD card into your computer
 1. Copy `boot.3dsx` and `boot.firm` from the Luma3DS `.zip` to the root of your SD card
   + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
+1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card, replacing any existing file
+1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card, merging it with any existing folder and replacing any existing files
 1. Reinsert your SD card into your device
 
 #### Section II - Configuring Luma3DS
@@ -28,6 +31,28 @@ This page prepares consoles with an existing modern boot9strap installation for 
 	* **"Show NAND or user string in System Settings"**
 1. Press (Start) to save and reboot
 
+#### Section III - CTRNAND Luma3DS
+
+1. Power off your device
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+  + If you do not boot into GodMode9, ensure that GodMode9.firm is in /luma/payloads/ and that payloads is correctly spelled
+1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
+1. Press (Home) to bring up the action menu
+1. Select "Scripts..."
+1. Select "GM9Megascript"
+1. Select "Scripts from Plailect's Guide"
+1. Select "Setup Luma3DS to CTRNAND"
+  + This will copy the updated version of Luma3DS to internal memory so that your device will be able to boot without an SD card inserted
+1. When prompted, press (A) to proceed
+1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press (A) to continue
+1. Press (B), then navigate to "Exit" to exit GM9Megascript
+  + When prompted, relock write permissions
+1. Press (Home) to bring up the action menu
+1. Select "Poweroff system" to power off your device
+
+The latest version of Luma3DS has been installed on your SD card and on internal memory.
+{: .notice--success}
 ___
 
 If you wish to re-install or update other homebrew applications, continue to [Finalizing Setup](finalizing-setup)


### PR DESCRIPTION
This ensures that anyone who is restoring or updating CFW also copies latest luma to ctrnand to prevent errors when booting SDless, allowing the link to be used for updateluma in place of a gist.