### PR TITLE
Fix typo

### DIFF
--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -27,7 +27,7 @@ These instructions work on USA, Europe, Japan, and Korea region consoles as indi
   + This `<ID0>` will be the same one that you used in [Seedminer](seedminer)
   + If `Nintendo DSiWare` does not exist, create it
 1. If there are any existing DSiWare backup files (`<8-character-id>.bin`) in this folder, move them to your PC
-  + This will leave you with an empty Nintendo DSiWare folder. Moving the files to your PC ensures you dont delete any intentional backups
+  + This will leave you with an empty Nintendo DSiWare folder. Moving the files to your PC ensures you don't delete any intentional backups
 1. Copy the `F00D43D5.bin` file from the BannerBomb3 `.zip` to the `Nintendo DSiWare` folder
 1. Reinsert your SD card into your device
 1. Power on your device


### PR DESCRIPTION
As the name says, fixes a missing apostrophe on the BannerBomb3 page.