### PR TITLE
Extract `boot.firm` and `boot.3dsx` when uninstalling CFW

### DIFF
--- a/_pages/en_US/uninstall-cfw.txt
+++ b/_pages/en_US/uninstall-cfw.txt
@@ -23,6 +23,7 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
 
 ### What You Need
 
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
 * The latest release of [DSiWare Uninstaller](https://github.com/MechanicalDragon0687/DSiWare-Uninstaller/releases/latest)
 * [safety_test.gm9]({{ base_path }}/gm9_scripts/safety_test.gm9)
@@ -32,6 +33,7 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
 #### Section I - Prep Work
 1. Power off your device
 1. Insert your SD card into your computer
+1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card
 1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
 1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card
 1. Copy `DSiWareUninstaller.3dsx` to the `/3ds/` folder on your SD card


### PR DESCRIPTION
**Description**

This PR adds a step to extract `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` when uninstalling CFW. This is important in case user does not have either for some reason, and none of the payloads boot or the Homebrew Launcher crashes. 
