### PR TITLE
godmode9-usage: power off instead of eject

### DIFF
--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -47,22 +47,21 @@ Some of the instructions below are only applicable to the latest version of GodM
 1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted
-1. Hold (R) and press (B) at the same time to eject your SD card
+1. Hold (R) and press (Start) at the same time to power off your device
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_###.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
 1. Reinsert your SD card into your device
-  + If your SD card was not detected, hold (R) and press (B) at the same time to remount it
 
 ## Restoring a NAND Backup
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Hold (R) and press (B) at the same time to eject your SD card
+1. Power off your device
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_###.bin` from your computer to the `/gm9/out/` folder on your SD card
 1. Reinsert your SD card into your device
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"


### PR DESCRIPTION
**Description**

Instead of launching then ejecting, just copy the NAND backup before turning on.

Instead of ejecting then reinserting, just turn off then copy out the NAND backup.