### PR TITLE
Updating B9S: use SafeB9SInstaller as `boot.firm`

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -23,7 +23,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 1. Power off your device
 1. Insert your console's SD card into your computer
   + This is the SD card from your 3DS, *not* the SD card from your flashcart
-1. Copy `SafeB9SInstaller.firm` to the root of your console's SD card and rename it to `boot.firm`
+1. Copy `SafeB9SInstaller.firm` from the SafeB9SInstaller `.zip` to the root of your SD card and rename it to `boot.firm`
 1. Copy `boot.3dsx` from the Luma3DS `.zip` to the root of your console's SD card
 1. Create a folder named `boot9strap` on the root of your console's SD card
 1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your console's SD card

--- a/_pages/en_US/updating-b9s.txt
+++ b/_pages/en_US/updating-b9s.txt
@@ -27,21 +27,21 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Insert your SD card into your computer
 1. Create a folder named `boot9strap` on the root of your SD card
 1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your SD card
-1. Copy `SafeB9SInstaller.firm` from the SafeB9SInstaller `.zip` to the `/luma/payloads/` folder on your SD card
+1. Copy `SafeB9SInstaller.firm` from the SafeB9SInstaller `.zip` to the root of your SD card and rename it to `boot.firm`
+  + If a `boot.firm` already exists, replace it
 1. Reinsert your SD card into your device
 
 #### Section II - Installing boot9strap
 
-1. Launch Luma3DS chainloader menu by holding (Start) during boot
-1. Launch SafeB9SInstaller by pressing (A)
+1. Power on your device
+  + This should automatically launch SafeB9SInstaller
 1. Wait for all safety checks to complete
 1. When prompted, input the key combo given to install boot9strap
-1. Once it has completed, hold (Start) while pressing (A) to reboot your device to the Luma3DS chainloader
-  + If you encounter an `argc = 0` error booting your device after the B9S update, just continue to fix it
+1. Once it has completed, force your device to power off by holding down the power button
+  + Your device will only boot to the SafeB9SInstaller screen until the next section is completed
 
 #### Section III - Update Luma3DS
 
-1. Power off your device
 1. Insert your SD card into your computer
 1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card, replacing the existing file
 1. Reinsert your SD card into your device


### PR DESCRIPTION
**Description**

Often, there are issues where the user updating boot9strap can't actually launch SafeB9SInstaller as they only have Luma3DS installed to CTRNAND. 

This should force the console to boot into SafeB9SInstaller.

There were some suggestions to download Luma 7.1 separately, but given the result would be the same either way (either it keeps rebooting to SafeB9SInstaller, or it keeps rebooting to Luma 7.1) this saves the need to download another file.
