### PR TITLE
Link directly to boot9strap in the main guide path

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -13,7 +13,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 * A magnet that triggers the sleep mode of your device (if using a folding style device)
 * Your ntrboot flashed flashcart
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
-* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`boot9strap-1.3.zip`; not the `devkit` file, not the `ntr` file)*
+* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.3/boot9strap-1.3.zip)
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) 
 
 ### Instructions

--- a/_pages/en_US/installing-boot9strap-(pichaxx).txt
+++ b/_pages/en_US/installing-boot9strap-(pichaxx).txt
@@ -15,7 +15,7 @@ This method of using Seedminer for further exploitation uses your `movable.sed` 
   + Your SD card must be inserted in your device to install Pokémon Picross
 * Your `movable.sed` file from completing [Seedminer](seedminer)
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
-* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`boot9strap-1.3.zip`; not the `devkit` file, not the `ntr` file)*
+* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.3/boot9strap-1.3.zip)
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
 * The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest)
 

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -13,7 +13,7 @@ Soundhax (when combined with universal-otherapp) is compatible with versions 1.0
 * The latest release of [Soundhax](http://soundhax.com) *(for your region, device, and version)*
   + If Soundhax appears in your browser as an unplayable video, press Ctrl+S or Cmd+S to save it to your computer
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
-* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`boot9strap-1.3.zip`; not the `devkit` file, not the `ntr` file)*
+* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.3/boot9strap-1.3.zip)
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
 * The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest)
 


### PR DESCRIPTION
This PR changes the links to boot9strap in the 3 methods that users will reasonably be following to link directly to boot9strap-1.3.zip, instead of having the user download and choose it manually from the repository.