### PR TITLE
fix: correct button label on bannerbomb instructions

### DIFF
--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -19,7 +19,7 @@ These instructions work on USA, Europe, Japan, and Korea region consoles as indi
 #### Section I - BannerBomb3
 1. Open [BannerBomb3 Tool](https://3ds.nhnarwhal.com/3dstools/bannerbomb3.php) on your computer
 1. Upload your movable.sed using the "Choose File" option
-1. Click "Go"
+1. Click "Build and Download"
   + This will download an exploit DSiWare called `F00D43D5.bin` inside of a zip file (`BannerBomb3.zip`)
 1. If your console is powered on, power off your console
 1. Insert your SD card into your computer
@@ -44,4 +44,3 @@ These instructions work on USA, Europe, Japan, and Korea region consoles as indi
 
 Continue to [Installing boot9strap (Fredtool)](installing-boot9strap-(fredtool))
 {: .notice--primary}
-

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -41,8 +41,8 @@ If you see a configuration menu, you already have CFW and continuing with these 
 1. Open [Fredtool](https://3ds.nhnarwhal.com/3dstools/fredtool.php) on your computer
 1. Select your `movable.sed` file for the "Your movable.sed" field
 1. Select your DSiWare Backup (`<8-character-id>.bin`) file for the "Your dsiware.bin" field
-1. Complete the "I'm not a robot" captcha
-1. Select "Start"
+1. Select "Verify files"
+1. Select "Build and Download"
 1. Wait for the process to complete
 1. When the process has completed, download your modified DSiWare archive from the site
   + This file contains 2 DSiWare backup files, one clean (unmodified) and one hax (exploited)
@@ -50,7 +50,7 @@ If you see a configuration menu, you already have CFW and continuing with these 
   + The `<ID0>` will be the same one that you used in [Seedminer](seedminer)
   + The `<ID1>` is a 32 character long folder inside of the `<ID0>`
   + If the `Nintendo DSiWare` folder does not exist, create it inside of the `<ID1>`
-1. Copy the `42383841.bin` file from the `output/hax/` folder of the downloaded DSiWare archive (`fredtool_output.zip`) to the `Nintendo DSiWare` folder
+1. Copy the `42383841.bin` file from the `output/hax/` folder of the downloaded DSiWare archive (`fredtool.zip`) to the `Nintendo DSiWare` folder
 1. Reinsert your SD card into your device
 1. Power on your device
 1. Launch System Settings on your device
@@ -100,7 +100,7 @@ At this point, your console will boot to Luma3DS by default as long as the SD ca
 
 1. Power off your device
 1. Insert your SD card into your computer
-1. Copy the `42383841.bin` file from the `output/clean/` folder of the downloaded DSiWare archive (`fredtool_output.zip`) to the `Nintendo 3DS/<ID0>/<ID1>/Nintendo DSiWare/` folder on your SD card
+1. Copy the `42383841.bin` file from the `output/clean/` folder of the downloaded DSiWare archive (`fredtool.zip`) to the `Nintendo 3DS/<ID0>/<ID1>/Nintendo DSiWare/` folder on your SD card
   + Replace the existing `42383841.bin` file
 1. Reinsert your SD card into your device
 1. Power on your device


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->

### BannerBomb
Minor pull request that corrects one of the instructions.

![image](https://user-images.githubusercontent.com/22801583/133997097-cff9a49c-54c1-4beb-a57e-85aaa65e16c7.png)

The button is labelled `Build and Download`, not `Go`.

### Fredtool

![image](https://user-images.githubusercontent.com/22801583/134144045-9977aa45-8da2-4e32-b092-88e912e9e922.png)

---

The final line deletions are from the `.editorconfig` file.

```ini
insert_final_newline = false
```

### Related
* Closes https://github.com/hacks-guide/Guide_3DS/issues/1918