### PR TITLE
ntrboot: bump system version number

### DIFF
--- a/_pages/en_US/ntrboot.txt
+++ b/_pages/en_US/ntrboot.txt
@@ -17,23 +17,23 @@ Note that carts with a "Time Bomb" will no longer be able to launch `.nds` files
 
 | Flashcart Name | Current Price | "Time Bomb"? | 3DS Versions? | DSi Versions? | Other Notes |
 |-|-:|:-:|:-:|:-:|-|
-| [**R4i-SDHC B9S**](http://www.nds-card.com/ProShow.asp?ProID=574) | $15.99 | September 3, 2024 | <= 11.14.0 | <= 1.4.5 | **Comes pre-flashed with ntrboot**; can be flashed back to an NDS flashcart. |
-| [**R4i Gold 3DS Plus**](http://www.nds-card.com/ProShow.asp?ProID=575) | $19.99 | No | <= 11.14.0 | <= 1.4.5 | **Comes pre-flashed with ntrboot** ([internal switch to switch between ntrboot and NDS modes]({{ "/images/screenshots/r4i-gold-3ds-plus.png" | absolute_url }})); do not manually flash with ntrboot. |
+| [**R4i-SDHC B9S**](http://www.nds-card.com/ProShow.asp?ProID=574) | $15.99 | September 3, 2024 | <= 11.15.0 | <= 1.4.5 | **Comes pre-flashed with ntrboot**; can be flashed back to an NDS flashcart. |
+| [**R4i Gold 3DS Plus**](http://www.nds-card.com/ProShow.asp?ProID=575) | $19.99 | No | <= 11.15.0 | <= 1.4.5 | **Comes pre-flashed with ntrboot** ([internal switch to switch between ntrboot and NDS modes]({{ "/images/screenshots/r4i-gold-3ds-plus.png" | absolute_url }})); do not manually flash with ntrboot. |
 | [**Acekard 2i**](http://www.nds-card.com/ProShow.asp?ProID=160) | $20.99 | No | <= 4.3.0 | <= 1.4.4 | |
 | [**DSTT**](http://www.nds-card.com/ProShow.asp?ProID=157) | $9.99 | No | None | None | Only models with [certain flash chips](https://gist.github.com/aspargas2/fa2a70aed3a7fe33f1f10bc264d9fab6) are compatible with ntrboot. |
-| [**R4i Gold 3DS**](http://www.nds-card.com/ProShow.asp?ProID=149) | $19.99 | No | <= 11.14.0 | <= 1.4.5 | All RTS revisions are compatible. |
-| [**R4i-SDHC 3DS RTS**](http://www.nds-card.com/ProShow.asp?ProID=146) | $13.99 | 1.85b: September 3, 2024 | <= 11.14.0 | <= 1.4.5 | |
-| [**R4iSDHC GOLD Pro 20XX**](http://www.nds-card.com/ProShow.asp?ProID=490) | $9.99 | 4.0b: September 3, 2024 | <= 11.14.0 | <= 1.4.5 | Only r4isdhc **.com** carts marked with a year between 2014 and 2020 are compatible. |
-| [**R4iSDHC RTS LITE 20XX**](http://www.nds-card.com/ProShow.asp?ProID=450) | $13.99 | 4.0b: September 3, 2024 | <= 11.14.0 | <= 1.4.5 | Only r4isdhc **.com** carts marked with a year between 2014 and 2020 are compatible. |
-| **Ace3DS X** | | No | <= 11.14.0 | <= 1.4.5 | **Comes pre-flashed with ntrboot** (external switch to switch between ntrboot ("3DS") and NDS modes); do not manually flash with ntrboot. |
-| **Ace3DS Plus** | | No | <= 11.14.0 | <= 1.4.5 | |
+| [**R4i Gold 3DS**](http://www.nds-card.com/ProShow.asp?ProID=149) | $19.99 | No | <= 11.15.0 | <= 1.4.5 | All RTS revisions are compatible. |
+| [**R4i-SDHC 3DS RTS**](http://www.nds-card.com/ProShow.asp?ProID=146) | $13.99 | 1.85b: September 3, 2024 | <= 11.15.0 | <= 1.4.5 | |
+| [**R4iSDHC GOLD Pro 20XX**](http://www.nds-card.com/ProShow.asp?ProID=490) | $9.99 | 4.0b: September 3, 2024 | <= 11.15.0 | <= 1.4.5 | Only r4isdhc **.com** carts marked with a year between 2014 and 2020 are compatible. |
+| [**R4iSDHC RTS LITE 20XX**](http://www.nds-card.com/ProShow.asp?ProID=450) | $13.99 | 4.0b: September 3, 2024 | <= 11.15.0 | <= 1.4.5 | Only r4isdhc **.com** carts marked with a year between 2014 and 2020 are compatible. |
+| **Ace3DS X** | | No | <= 11.15.0 | <= 1.4.5 | **Comes pre-flashed with ntrboot** (external switch to switch between ntrboot ("3DS") and NDS modes); do not manually flash with ntrboot. |
+| **Ace3DS Plus** | | No | <= 11.15.0 | <= 1.4.5 | |
 | **Gateway Blue** | | No | 4.1.0 - 4.5.0 | <= 1.4.5 | |
-| **Infinity 3 R4i** | | No | <= 11.14.0 | <= 1.4.5 | |
+| **Infinity 3 R4i** | | No | <= 11.15.0 | <= 1.4.5 | |
 | **R4 3D Revolution** | | No | None | None | |
 | **R4i Gold 3DS Deluxe "Starter"** | | No | 4.1.0 - 4.5.0 | <= 1.4.5 | |
 | **R4i Ultra** | | No | <= 4.3.0 | <= 1.4.5 | |
-| **R4i-SDHC 3DS RTS Deluxe Edition** | | Unknown | <= 11.14.0 | <= 1.4.5 | |
-| **R4iSDHC Dual-Core 20XX** | | 4.0b: September 3, 2024 | <= 11.14.0 | <= 1.4.5 | Only r4isdhc **.com** carts marked with a year between 2014 and 2020 are compatible. |
+| **R4i-SDHC 3DS RTS Deluxe Edition** | | Unknown | <= 11.15.0 | <= 1.4.5 | |
+| **R4iSDHC Dual-Core 20XX** | | 4.0b: September 3, 2024 | <= 11.15.0 | <= 1.4.5 | Only r4isdhc **.com** carts marked with a year between 2014 and 2020 are compatible. |
 
   ![]({{ "/images/screenshots/ntrboot-flashcarts.png" | absolute_url }})
   {: .notice--info}


### PR DESCRIPTION
**Description**

Burguers is insistent.
Bump system version number for all carts that were supported on 11.14. Blacklists were not updated.

