### PR TITLE
dumping: do not trim NDS dumps

### DIFF
--- a/_pages/en_US/dumping-titles-and-game-cartridges.txt
+++ b/_pages/en_US/dumping-titles-and-game-cartridges.txt
@@ -41,8 +41,9 @@ Insert the game cartridge you intend to dump into your device
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Navigate to `[C:] GAMECART`
 1. Follow the steps applicable to your game cartridge:
-  + **3DS Game Cartridge:** Press (A) on `[TitleID].trim.3ds` to select it
-  + **NDS Game Cartridge:** Press (A) on `[TitleID].trim.nds` to select it
+    + **3DS Game Cartridge:** Press (A) on `[TitleID].trim.3ds` to select it
+    + **NDS Game Cartridge:** Press (A) on `[TitleID].nds` to select it
+        - Trimmed dumps are not recommended for NDS games in general, as they can cause various playback issues
 1. Select "Copy to 0:/gm9/out"
 1. Your non-installable `.3ds` or `.nds` formatted file will be outputted to the `/gm9/out/` folder on your SD card
 


### PR DESCRIPTION
**Description**

Trimming in general causes playback issues in some games. It is also known to completely break cloneboot compatibility, and, while a fix for the latter is stated for GodMode9 release, it's just not worth the trouble.
