### PR TITLE
Kartdlphax

### DIFF
--- a/_data/navigation/en_US.yml
+++ b/_data/navigation/en_US.yml
@@ -131,5 +131,8 @@ sidebar_pages:
     title: Installing boot9strap (PicHaxx)
     url: installing-boot9strap-(pichaxx)
   -
+    title: Installing boot9strap (kartdlphax)
+    url: installing-boot9strap-(kartdlphax)
+  -
     title: Finalizing Setup
     url: finalizing-setup

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -61,5 +61,6 @@ The letter and number after the system version (for example, 11.15.0-**47U**) is
 
 A number of methods that work on all versions are available, but require additional hardware. If possible, you should follow one of the software methods listed above instead.
 
+1. [Installing boot9strap (kartdlphax)](installing-boot9strap-(kartdlphax)) - requires a 3DS with custom firmware and a copy of Mario Kart 7
 1. [ntrboot](ntrboot) - requires compatible DS flashcart
 1. [Installing boot9strap (Hardmod)](installing-boot9strap-(hardmod)) - requires soldering

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -1,0 +1,87 @@
+---
+title: "Installing boot9strap (kartdlphax)"
+---
+
+{% include toc title="Table of Contents" %}
+
+### Required Reading
+
+kartdlphax is an exploit for the Download Play mode of Mario Kart 7. It can be used with universal-otherapp to install custom firmware on target devices.
+
+In order to follow these instructions, you will need the following:
+
+- A second 3DS with custom firmware (the **source 3DS**) that is the same region as the 3DS you are trying to modify (the **target 3DS**)
+- A physical or digital copy of Mario Kart 7 that is the same region as both consoles
+- An SD card for both devices
+	
+### What You Need
+
+On the **source 3DS** (the 3DS with custom firmware):
+
+* The latest release of [kartdlphax](https://github.com/mariohackandglitch/kartdlphax/releases/latest)
+* The latest release of [Luma3DS 3GX Loader Edition](https://github.com/Nanquitas/Luma3DS/releases/tag/v10.2.1)
+
+On the **target 3DS** (the 3DS that you are trying to modify):
+
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.3/boot9strap-1.3.zip)
+* The latest release of [standard Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+
+#### Section I - Prep Work (source 3DS)
+
+1. Insert the SD card of your **source 3DS** in your computer
+1. Copy Luma 3GX Loader Edition's `boot.firm` to the root of the **source 3DS**'s SD card
+1. Copy kartdlphax's `plugin.3gx` to the following directory on the **source 3DS**'s SD card, depending on the **region of your copy of Mario Kart 7**:
+  - USA Mario Kart 7: `luma/plugins/0004000000030800`
+  - EUR Mario Kart 7: `luma/plugins/0004000000030700`
+  - JPN Mario Kart 7: `luma/plugins/0004000000030600`
+  - Create the `plugins` and `00040000...` folder if they do not exist
+1. Eject the SD card and put it in the **source 3DS**
+
+#### Section II - Prep Work (target 3DS)
+
+1. Insert the SD card of your **target 3DS** in your computer
+1. Copy `boot.firm` and `boot.3dsx` from the standard Luma3DS `.zip` to the root of your SD card
+1. Create a folder named `boot9strap` on the root of your SD card
+1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your SD card
+1. Copy `SafeB9SInstaller.bin` from the SafeB9SInstaller `.zip` to the root of your SD card
+1. Eject the SD card and put it in the **target 3DS**
+
+#### Section III - kartdlphax
+
+1. Power on the **source 3DS**
+  - If you are prompted to set up Luma3DS, just press START to save the configuration
+1. Once in the home menu, press (Left Shoulder) + (Down D-Pad) + (Select) to bring up the Rosalina menu
+1. Select "Enable plugin loader"
+1. Press (B) to exit the Rosalina menu
+1. Launch Mario Kart 7
+  - kartdlphax should tell you that it is running
+1. Navigate to `Local Multiplayer` -> `Create Group`
+1. Power on the **target 3DS**
+1. On the **target 3DS**, open the Download Play application (![]({{ "/images/download-play-icon.png" | absolute_url }}){: height="24px" width="24px"}), then select "Nintendo 3DS"
+1. Join the group created by the **source 3DS**
+1. Once multiplayer has loaded, navigate to `Grand Prix` -> `50cc` -> (any driver) -> `Mushroom Cup`
+1. Wait a while
+1. If the exploit was successful, the **target 3DS** will have booted into SafeB9SInstaller
+
+#### Section IV - SafeB9SInstaller
+
+1. Wait for all checks to complete
+1. When prompted, input the key combo given on the top screen to install boot9strap
+1. Once it has completed, press (A) to reboot your device
+
+#### Section V - Configuring Luma3DS
+
+1. Your target 3DS should have rebooted into the Luma3DS configuration menu
+1. Use the (A) button and the D-Pad to turn on the following:
+  - **"Show NAND or user string in System Settings"**
+
+At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+  + Luma3DS does not look any different from the normal HOME menu. If your console has booted into the HOME menu, it is running custom firmware.
+  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + You will **not** need to use your **source 3DS** to complete any further steps on this guide.
+
+___
+
+### Continue to [Finalizing Setup](finalizing-setup)
+{: .notice--primary}

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -32,10 +32,10 @@ On the **target 3DS** (the 3DS that you are trying to modify):
 1. Insert the SD card of your **source 3DS** in your computer
 1. Copy Luma 3GX Loader Edition's `boot.firm` to the root of the **source 3DS**'s SD card
 1. Copy kartdlphax's `plugin.3gx` to the following directory on the **source 3DS**'s SD card, depending on the **region of your copy of Mario Kart 7**:
-  - USA Mario Kart 7: `luma/plugins/0004000000030800`
-  - EUR Mario Kart 7: `luma/plugins/0004000000030700`
-  - JPN Mario Kart 7: `luma/plugins/0004000000030600`
-  - Create the `plugins` and `00040000...` folder if they do not exist
+  - USA: `luma/plugins/0004000000030800`
+  - EUR: `luma/plugins/0004000000030700`
+  - JPN: `luma/plugins/0004000000030600`
+  - Create the `plugins` and `00040000...` folders if they do not already exist
 1. Eject the SD card and put it in the **source 3DS**
 
 #### Section II - Prep Work (target 3DS)
@@ -55,13 +55,16 @@ On the **target 3DS** (the 3DS that you are trying to modify):
 1. Select "Enable plugin loader"
 1. Press (B) to exit the Rosalina menu
 1. Launch Mario Kart 7
+  - Ensure that wireless connectivity is enabled
   - kartdlphax should tell you that it is running
 1. Navigate to `Local Multiplayer` -> `Create Group`
 1. Power on the **target 3DS**
+  - Ensure that wireless connectivity is enabled
 1. On the **target 3DS**, open the Download Play application (![]({{ "/images/download-play-icon.png" | absolute_url }}){: height="24px" width="24px"}), then select "Nintendo 3DS"
 1. Join the group created by the **source 3DS**
+1. Select "Start" on the **source 3DS** once it has detected the **target 3DS**
 1. Once multiplayer has loaded, navigate to `Grand Prix` -> `50cc` -> (any driver) -> `Mushroom Cup`
-1. Wait a while
+1. Wait a while (a percentage should be displayed on the **source 3DS**)
 1. If the exploit was successful, the **target 3DS** will have booted into SafeB9SInstaller
 
 #### Section IV - SafeB9SInstaller

--- a/_pages/en_US/site-navigation.txt
+++ b/_pages/en_US/site-navigation.txt
@@ -50,6 +50,7 @@ sitemap: false
 + [Installing boot9strap (Fredtool)](installing-boot9strap-(fredtool))
 + [Installing boot9strap (Frogtool)](installing-boot9strap-(frogtool))
 + [Installing boot9strap (Hardmod)](installing-boot9strap-(hardmod))
+* [Installing boot9strap (kartdlphax)](installing-boot9strap-(kartdlphax))
 + [Installing boot9strap (MSET)](installing-boot9strap-(mset))
 + [Installing boot9strap (ntrboot)](installing-boot9strap-(ntrboot))
 + [Installing boot9strap (PicHaxx)](installing-boot9strap-(pichaxx))


### PR DESCRIPTION
As suggested by @MechanicalDragon0687. This PR:

- Adds kartdlphax instructions (based on [this gist](https://gist.github.com/lilyuwuu/adc540e700aa9d3aa0ed882ce51756b2)).
- Adds it to Get Started as a method above ntrboot (as it is more likely for someone to have a second 3DS and MK7 than a compatible DS flashcart).

While I was initially hesitant on adding it to a page other than site navigation, I feel it's a reasonable alternative to Seedminer for unminable consoles (and at the very least, it's a lot more feasible than hardmodding, where we still don't have current NFIRMs up). Just need to tweak the text on the BFM site so that it doesn't say ntrboot is the only option...