### PR TITLE
Fix privacy policy link

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -2,4 +2,4 @@
 {% assign split_path = page.path | split: "/" %}
 {% assign locale = split_path[1] %}
 {% assign titles = site.data.navigation[locale].footer %}
-<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }} - <a href="https://github.com/hacks-guide/Guide_3DS">{{ titles[0].title }}</a> - <a href="site-navigation">{{ titles[1].title }}</a> - <a href="privacy-policy">{{ titles[3].title }}</a></div>
+<div class="page__footer-copyright">&copy; {{ site.time | date: '%Y' }} {{ site.name | default: site.title }} - <a href="https://github.com/hacks-guide/Guide_3DS">{{ titles[0].title }}</a> - <a href="site-navigation">{{ titles[1].title }}</a> - <a href="privacy-policy">{{ titles[2].title }}</a></div>


### PR DESCRIPTION
The link to the privacy policy was loading the fourth title because `titles[3]` is gonna be the fourth element in the array. Since there are only three in the array and the third in `en_gb` is 'Privacy Policy', I'm gonna assume that it's meant to be `titles[2]`.

I make this mistake a lot myself.

This fixes it so that the link the the privacy policy is visible.
