### PR TITLE
formatting-sd-win: use SD Card Formatter for 32GB and less

### DIFF
--- a/_pages/en_US/formatting-sd-(windows).txt
+++ b/_pages/en_US/formatting-sd-(windows).txt
@@ -14,10 +14,10 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 
 ### What You Need
 
-* **For SD cards 32GB or less:** the latest version of [SD Formatter](https://www.sdcard.org/downloads/formatter/sd-memory-card-formatter-for-windows-download/)
-* **For SD cards larger than 32GB:** The latest version of [guiformat](http://ridgecrop.co.uk/index.htm?guiformat.htm)
+* **For SD cards 32GB or smaller:** the latest version of [SD Formatter](https://www.sdcard.org/downloads/formatter/sd-memory-card-formatter-for-windows-download/)
+* **For SD cards 64GB or larger:** The latest version of [guiformat](http://ridgecrop.co.uk/index.htm?guiformat.htm)
 
-### Instructions (32GB or less)
+### Instructions (32GB or smaller)
 
 1. Insert your SD card into your computer
 1. If the SD card has any files and folders on it, copy everything to a folder on your computer
@@ -37,7 +37,7 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 1. Close SD Card Formatter
 1. If the SD card had any files and folders on it before the format, copy everything back from your computer
 
-### Instructions (over 32GB)
+### Instructions (64GB or larger)
 
 1. Insert your SD card into your computer
 1. If the SD card has any files and folders on it, copy everything to a folder on your computer
@@ -48,8 +48,8 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 	{: .notice--danger}
 
 1. Select a size for "Allocation unit size"
-  + If the SD card is 64GB or below, choose 32768
-  * If the SD card is above 64GB, choose 65536
+  + If the SD card is 64GB, choose 32768
+  * If the SD card is larger than 64GB, choose 65536
 1. Enter anything for "Volume label"
 1. Ensure that "Quick Format" is selected
 1. Click "Start"

--- a/_pages/en_US/formatting-sd-(windows).txt
+++ b/_pages/en_US/formatting-sd-(windows).txt
@@ -14,9 +14,30 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 
 ### What You Need
 
-* The latest version of [guiformat](http://ridgecrop.co.uk/index.htm?guiformat.htm)
+* **For SD cards 32GB or less:** the latest version of [SD Formatter](https://www.sdcard.org/downloads/formatter/sd-memory-card-formatter-for-windows-download/)
+* **For SD cards larger than 32GB:** The latest version of [guiformat](http://ridgecrop.co.uk/index.htm?guiformat.htm)
 
-### Instructions
+### Instructions (32GB or less)
+
+1. Insert your SD card into your computer
+1. If the SD card has any files and folders on it, copy everything to a folder on your computer
+1. Run `SD Card Formatter Setup` (the `.exe` file) in the downloaded `.zip` file with Adminstrator privileges, then install the program
+1. Run `SD Card Formatter` from the Start Menu
+1. Select your SD card's drive letter for "Select card"
+
+	Make sure you choose the correct drive letter, otherwise you might accidentally erase the wrong drive!
+	{: .notice--danger}
+
+1. Enter anything for "Volume label"
+1. Ensure that "Quick Format" is selected
+1. Click "Format"
+1. Click "OK"
+1. Wait for the format to finish
+1. Click "OK"
+1. Close SD Card Formatter
+1. If the SD card had any files and folders on it before the format, copy everything back from your computer
+
+### Instructions (over 32GB)
 
 1. Insert your SD card into your computer
 1. If the SD card has any files and folders on it, copy everything to a folder on your computer
@@ -37,7 +58,7 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 1. Click "Close"
 1. If the SD card had any files and folders on it before the format, copy everything back from your computer
 
-### Common Errors
+### Common Errors using guiformat
 
 * Failed to open device: GetLastError()=32
   + Close everything that may be using the SD card, such as any File Explorer windows.


### PR DESCRIPTION
**Description**

guiformat forces FAT32 on the system. This is generally okay for SDXC+ cards, but SD Card Formatter formats SD cards as according to official SD specifications, which would be much more beneficial for SD and SDHC cards. 

This automatically formats to 32KB allocation unit size, as well as formats to FAT16 for SD and FAT32 for SDHC, both of which the 3DS supports.
