### PR TITLE
uninstall-cfw: fix TWLFix troubleshooting link

### DIFF
--- a/_pages/en_US/uninstall-cfw.txt
+++ b/_pages/en_US/uninstall-cfw.txt
@@ -59,7 +59,7 @@ The purpose of this section is to check whether built-in DS mode applications wi
   + If your console displays the Japanese version of Flipnote Studio, a black screen, or an error message, the test has failed
 1. Power off your device
 
-If either of these tests has failed, DS mode, DS Download Play, and/or DS Connection Settings may be inaccessible once CFW is uninstalled! You should [fix DS mode](troubleshooting#dsi--ds-functionality-is-broken-after-completing-the-guide) before continuing.
+If either of these tests has failed, DS mode, DS Download Play, and/or DS Connection Settings may be inaccessible once CFW is uninstalled! You should [fix DS mode](troubleshooting#dsi--ds-functionality-is-broken-or-has-been-replaced-with-flipnote-studio) before continuing.
 {: .notice--warning}
 
 #### Section III - Safety Test


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->
Fixes troubleshooting link not redirecting to the correct section after troubleshooting overhaul.