### PR TITLE
faq: Clarify which regions actually have NNID

### DIFF
--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -34,7 +34,7 @@ title: "FAQ"
 **A:** No. Devices with custom firmware can still use the eShop and run physical cartridges as any other 3DS can.
 
 <a name="faq_NNID" />**Q:** *Can I keep my NNID?*    
-**A:** Your NNID will not be affected by this guide. Also, if your system is KOR, CHN or TWN region, these systems do not have NNID functionality at all, so these systems will be unaffected anyway.
+**A:** Your NNID (if you have one) will not be affected by this guide. Devices with a region of KOR, CHN, or TWN do not have NNID functionality to begin with and are thus unaffected.
 
 <a name="faq_ban" />**Q:** *Will my 3DS be banned for having CFW?*    
 **A:** There was a ban wave in May 2017 that banned CFW users from online play (eShop access, NNIDs, and Nintendo Accounts were unaffected), seemingly at random. A ban wave at such a scale has not been seen since. That being said, we don't know what Nintendo may have in store in the future. At this time, we don't think that bans are something that you need to worry about.

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -34,7 +34,7 @@ title: "FAQ"
 **A:** No. Devices with custom firmware can still use the eShop and run physical cartridges as any other 3DS can.
 
 <a name="faq_NNID" />**Q:** *Can I keep my NNID?*    
-**A:** Your NNID will not be affected by this guide.
+**A:** Your NNID will not be affected by this guide. Also, if your system is KOR, CHN or TWN region, these systems do not have NNID functionality at all, so these systems will be unaffected anyway.
 
 <a name="faq_ban" />**Q:** *Will my 3DS be banned for having CFW?*    
 **A:** There was a ban wave in May 2017 that banned CFW users from online play (eShop access, NNIDs, and Nintendo Accounts were unaffected), seemingly at random. A ban wave at such a scale has not been seen since. That being said, we don't know what Nintendo may have in store in the future. At this time, we don't think that bans are something that you need to worry about.


### PR DESCRIPTION
**Description**

While translating, it was brought up that the South Korean modding community has practically 0 concept of what an NNID is.

This makes sense: KOR region consoles don't have such a thing.

Therefore, this is clarified.
