### PR TITLE
Finalizing Setup rework

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -10,14 +10,14 @@ The file `boot.firm` is what is launched by boot9strap itself after it finishes 
 
 On this page, we will make critical system file backups and install the following homebrew programs:
 
-+  **FBI** *(installs CIA formatted games and applications)*
++  **FBI** *(installs CIA formatted applications)*
 +  **Anemone3DS** *(installs custom themes)*
 +  **Checkpoint** *(backs up and restores save files for 3DS and DS games)*
-+  **Universal-Updater** *(a homebrew app store for downloading homebrew from the 3DS over wifi)*
++  **Universal-Updater** *(a homebrew app store for downloading homebrew from the 3DS over Wi-Fi)*
 +  **GodMode9** *(multipurpose tool which can do NAND and cartridge functions)*
 +  **Homebrew Launcher Loader** *(launches the Homebrew Launcher)*
 +  **DSP1** *(allows homebrew applications to have sound)*
-+  **ctr-no-timeoffset** *(removes the RTC offset so that the home menu and RTC timestamps match)*
++  **ctr-no-timeoffset** *(sets the Home Menu time to match the internal Real-Time Clock)*
 
 It is not recommended to skip downloading any of these applications, as many of them will be used later on this page.
 {: .notice--warning}
@@ -161,7 +161,7 @@ You're done! Custom firmware is now fully configured on your device.
 Here are some keycombos that you should know:
 
 - Holding (Select) on boot will launch the Luma3DS configuration menu.
-- Holding (Start) on boot will launch the GodMode9, or if you have multiple payloads in `/luma/payloads/`, the Luma3DS chainloader.
+- Holding (Start) on boot will launch GodMode9, or if you have multiple payloads in `/luma/payloads/`, the Luma3DS chainloader.
 - By default, pressing (Left Shoulder) + (Down D-Pad) + (Select) while in 3DS mode will open the Rosalina menu, where you can check system information, take screenshots, enable cheats, and more. This can be changed from the Rosalina menu.
 - Holding (Start) + (Select) + (X) on boot will dump `boot9.bin`, `boot11.bin`, and `otp.bin` to the `boot9strap` folder on your SD card.
 {% endcapture %}

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -32,7 +32,6 @@ If your previous CFW setup was EmuNAND-based and you wish to move the contents o
 
 * The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest) (get the `.cia` file)
 * The v3.7.4 release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/tag/v3.7.4) (get the `.cia` file)
-* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) (get the `.cia` file)
 * The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest) (get the `.cia` file)
 * The latest release of [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest) (get the `.cia` file)
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -22,6 +22,9 @@ On this page, we will make critical system file backups and install the followin
 It is not recommended to skip downloading any of these applications, as many of them will be used later on this page.
 {: .notice--warning}
 
+If your **New 3DS** was on firmware 2.1.0 before following this guide, you should [restore your NAND backup](https://3ds.hacks.guide/godmode9-usage#restoring-a-nand-backup) before continuing.
+{: .notice--warning}
+
 If your previous CFW setup was EmuNAND-based and you wish to move the contents of your EmuNAND/RedNAND to SysNAND, follow [Move EmuNAND](move-emunand) before following this page. If you don't know what an EmuNAND is, this doesn't apply to you.
 {: .notice--info}
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -30,20 +30,18 @@ If your previous CFW setup was EmuNAND-based and you wish to move the contents o
 
 ### What You Need
 
-**CIA Files** (get the `.cia` file)
-* The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest)
-* The v3.7.4 release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/tag/v3.7.4)
-* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest)
-* The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest)
-* The latest release of [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest)
+* The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest) (get the `.cia` file)
+* The v3.7.4 release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/tag/v3.7.4) (get the `.cia` file)
+* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) (get the `.cia` file)
+* The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest) (get the `.cia` file)
+* The latest release of [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest) (get the `.cia` file)
 
-**3DSX files** (get the `.3dsx` file)
-* The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
-* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest)
+* The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest) (get the `.3dsx` file)
+* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest) (get the `.3dsx` file)
 
 **Other**
-* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) (both the `.cia` and `.3dsx` files)
-* The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
+* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) (get both the `.cia` and `.3dsx` files)
+* The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (get the GodMode9 `.zip` file)
 
 ### Instructions
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -6,11 +6,9 @@ title: "Finalizing Setup"
 
 ### Required Reading
 
-The file `boot.firm` is what is launched by boot9strap itself after it finishes loading off of NAND, and can be any valid arm9 payload in the FIRM format. This file can be replaced at any time, although Luma3DS allows for the launch of other arm9 payloads in the FIRM format using the Luma3DS chainloader.
+The file `boot.firm` is what is launched by boot9strap itself after it finishes loading off of NAND. In this case, we are using Luma3DS by [LumaTeam](https://github.com/LumaTeam/) to patch the device, allowing it to run homebrew software.
 
-In this case, we use Luma3DS by [LumaTeam](https://github.com/LumaTeam/) to boot a patched SysNAND directly, allowing us to completely bypass the need for any kind of EmuNAND, vastly simplifying the usage of a hacked 3DS in addition to saving SD card space.
-
-During this process, we also setup programs such as the following:
+On this page, we will make critical system file backups and install the following homebrew programs:
 
 +  **FBI** *(installs CIA formatted games and applications)*
 +  **Anemone3DS** *(installs custom themes)*
@@ -19,18 +17,30 @@ During this process, we also setup programs such as the following:
 +  **GodMode9** *(multipurpose tool which can do NAND and cartridge functions)*
 +  **Homebrew Launcher Loader** *(launches the Homebrew Launcher)*
 +  **DSP1** *(allows homebrew applications to have sound)*
-+  **ctr-no-timeoffset** *(removes the rtc offset so that the home menu and rtc timestamps match)*
++  **ctr-no-timeoffset** *(removes the RTC offset so that the home menu and RTC timestamps match)*
+
+It is not recommended to skip downloading any of these applications, as many of them will be used later on this page.
+{: .notice--warning}
+
+If your previous CFW setup was EmuNAND-based and you wish to move the contents of your EmuNAND/RedNAND to SysNAND, follow [Move EmuNAND](move-emunand) before following this page. If you don't know what an EmuNAND is, this doesn't apply to you.
+{: .notice--info}
 
 ### What You Need
 
-* The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest) *(the `.cia` file)*
-* The 3.7.4 release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/tag/v3.7.4) *(the `.cia` file)*
-* The latest release of [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest) *(the `.cia` file)*
+**CIA Files**
+* The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest)
+* The v3.7.4 release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/tag/v3.7.4)
+* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest)
 * The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest)
-* The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
-* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest) *(the `.cia` file)*
-* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) *(the `.cia` and `.3dsx` files)*
+* The latest release of [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest)
+
+**3DSX files**
 * The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
+* The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest)
+
+**Other**
+* The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) (both the `.cia` and `.3dsx` files)
+* The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
 
 ### Instructions
 
@@ -38,17 +48,11 @@ During this process, we also setup programs such as the following:
 
 1. Power off your device
 1. Insert your SD card into your computer
+1. Create a folder named `cias` on the root of your SD card if it does not already exist
+1. Copy all of the CIA files (`Anemone3DS.cia`, `Checkpoint.cia`, `FBI.cia`, `Homebrew_Launcher.cia`, and `Universal-Updater.cia`) to the `/cias/` folder on your SD card
 1. Create a folder named `3ds` on the root of your SD card if it does not already exist
     + This folder stores homebrew applications and data; it is different from the `Nintendo 3DS` folder that the device automatically generates
-1. Create a folder named `cias` on the root of your SD card if it does not already exist
-1. Copy `ctr-no-timeoffset.3dsx` to the `/3ds/` folder on your SD card
-1. Copy `FBI.3dsx` to the `/3ds/` folder on your SD card
-1. Copy `Homebrew_Launcher.cia` to the `/cias/` folder on your SD card
-1. Copy `FBI.cia` to the `/cias/` folder on your SD card
-1. Copy `DSP1.cia` to the `/cias/` folder on your SD card
-1. Copy `Anemone3DS.cia` to the `/cias/` folder on your SD card
-1. Copy `Checkpoint.cia` to the `/cias/` folder on your SD card
-1. Copy `Universal-Updater.cia` to the `/cias/` folder on your SD card
+1. Copy all of the 3DSX files (`ctr-no-timeoffset.3dsx`, `DSP1.3dsx`, and `FBI.3dsx`) to the `/3ds/` folder on your SD card
 1. Create a folder named `payloads` in the `luma` folder on your SD card if it does not already exist
 1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
 1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card
@@ -56,12 +60,6 @@ During this process, we also setup programs such as the following:
 1. Power on your device
 
 #### Section II - Updating the System
-
-If, while following a previous version of this guide, you CTRTransfered your *New 3DS* to 2.1.0, you should now [restore your NAND backup](godmode9-usage#restoring-a-nand-backup) before doing this section.
-{: .notice--danger}
-
-If, before following this guide, you already had an EmuNAND setup and would like to move the contents of your previous EmuNAND to your new SysNAND CFW, now is the time to [follow Move EmuNAND](move-emunand) before doing this section.
-{: .notice--info}
 
 1. Update your device by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
   + Updates while using B9S + Luma (what you have) are safe
@@ -82,23 +80,21 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Press (Home), then close Download Play
 1. Launch the Download Play application
 1. Your device should load the Homebrew Launcher
+
+#### Section IV - RTC and DSP Setup
 1. Launch ctr-no-timeoffset from the list of homebrew
 1. Press (A) to set the offset to 0
   + This will set the system clock to match the RTC date&time (which we will set soon)
 1. Press (Start) to return to the Homebrew Launcher
+1. Launch the DSP1 application
+1. Once it has completed, press (B) to self-delete the app and return to the Homebrew Launcher
+
+#### Section V - Installing CIAs
 1. Launch FBI from the list of homebrew
-
-#### Section IV - Installing CIAs
-
 1. Navigate to `SD` -> `cias`
 1. Select "\<current directory>"
 1. Select the "Install and delete all CIAs" option, then press (A) to confirm
 1. Press (Home), then close Download Play
-
-#### Section V - DSP Dump
-
-1. Launch the DSP1 application
-1. Once it has completed, press (B) to self-delete the app and return to the home menu
 
 #### Section VI - CTRNAND Luma3DS
 
@@ -156,41 +152,24 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 ___
 
+You're done! Custom firmware is now fully configured on your device.
+{: .notice--success}
+
 #### Information and Notes
 
 {% capture notice-6 %}
-You will now boot Luma3DS CFW by default.
+Here are some keycombos that you should know:
 
-You can now hold (Select) on boot to launch the Luma3DS configuration menu.
-
-You can now hold (Start) on boot to launch the Luma3DS chainloader menu (note that the Luma3DS chainloader menu is only displayed if there is more than one payload detected).
-
-You can now hold (Start) + (Select) + (X) on boot to dump the ARM11 bootrom (`boot11.bin`), the ARM9 bootrom (`boot9.bin`), and your console unique OTP (`OTP.bin`) to the `/boot9strap/` folder on your SD card (note that this will not have any kind of prompt or message).
-
-You can now press (L) + (Down) + (Select) while the system is booted to open the Rosalina menu integrated into Luma3DS. For a full list of Rosalina features, please see the [Luma3DS v8.0 Release](https://github.com/AuroraWright/Luma3DS/releases/tag/v8.0)
+- Holding (Select) on boot will launch the Luma3DS configuration menu.
+- Holding (Start) on boot will launch the GodMode9, or if you have multiple payloads in `/luma/payloads/`, the Luma3DS chainloader.
+- By default, pressing (Left Shoulder) + (Down D-Pad) + (Select) while in 3DS mode will open the Rosalina menu, where you can check system information, take screenshots, enable cheats, and more. This can be changed from the Rosalina menu.
+- Holding (Start) + (Select) + (X) on boot will dump `boot9.bin`, `boot11.bin`, and `otp.bin` to the `boot9strap` folder on your SD card.
 {% endcapture %}
 
 <div class="notice--info">{{ notice-6 | markdownify }}</div>
 
-{% capture notice-6 %}
-If you would like to upgrade to a bigger sized SD card, all you have to do is format your new SD card as FAT32 and copy paste the contents of the old SD card onto the new SD card.
+See [here](https://3ds.eiphax.tech/tips.html) for some suggestions on things to do with custom firmware.
+{: .notice--info}
 
-If your new SD card is bigger than 32GB, then you have to use a different tool to format it, such as [guiformat (Windows)](formatting-sd-(windows)), [Disk Utility (Mac)](formatting-sd-(mac)), or [cfdisk (Linux)](formatting-sd-(linux)).
-{% endcapture %}
-
-<div class="notice--info">{{ notice-6 | markdownify }}</div>
-
-For information on changing your device to another region, check out the [Region Changing](region-changing) page.
-{: .notice--success}
-
-For information on using GodMode9's various features, check out the [GodMode9 Usage](godmode9-usage) page.
-{: .notice--success}
-
-For information on using Luma3DS's various features, check out [its wiki](https://github.com/AuroraWright/Luma3DS/wiki/Options-and-usage).
-{: .notice--success}
-
-For information on installing custom themes and splash screens, check out [Theme Plaza](https://themeplaza.art/).
-{: .notice--success}
-
-For information on using Gateshark cheat codes on Luma3DS, check out [Checkpoint](https://github.com/FlagBrew/Checkpoint).
-{: .notice--success}
+For information on using GodMode9's various features, check out the [GodMode9 Usage](godmode9-usage) and [Dumping Titles and Game Cartridges](dumping-titles-and-game-cartridges) pages.
+{: .notice--info}

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -39,7 +39,6 @@ If your previous CFW setup was EmuNAND-based and you wish to move the contents o
 * The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest) (get the `.3dsx` file)
 * The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest) (get the `.3dsx` file)
 
-**Other**
 * The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest) (get both the `.cia` and `.3dsx` files)
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (get the GodMode9 `.zip` file)
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -30,14 +30,14 @@ If your previous CFW setup was EmuNAND-based and you wish to move the contents o
 
 ### What You Need
 
-**CIA Files**
+**CIA Files** (get the `.cia` file)
 * The latest release of [Anemone3DS](https://github.com/astronautlevel2/Anemone3DS/releases/latest)
 * The v3.7.4 release of [Checkpoint](https://github.com/FlagBrew/Checkpoint/releases/tag/v3.7.4)
 * The latest release of [FBI](https://github.com/Steveice10/FBI/releases/latest)
 * The latest release of [Homebrew Launcher Wrapper](https://github.com/mariohackandglitch/homebrew_launcher_dummy/releases/latest)
 * The latest release of [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest)
 
-**3DSX files**
+**3DSX files** (get the `.3dsx` file)
 * The latest release of [ctr-no-timeoffset](https://github.com/ihaveamac/ctr-no-timeoffset/releases/latest)
 * The latest release of [DSP1](https://github.com/zoogie/DSP1/releases/latest)
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -22,7 +22,7 @@ On this page, we will make critical system file backups and install the followin
 It is not recommended to skip downloading any of these applications, as many of them will be used later on this page.
 {: .notice--warning}
 
-If your **New 3DS** was on firmware 2.1.0 before following this guide, you should [restore your NAND backup](https://3ds.hacks.guide/godmode9-usage#restoring-a-nand-backup) before continuing.
+If your **New 3DS** was on firmware 2.1.0 before following this guide, you should [restore your NAND backup](godmode9-usage#restoring-a-nand-backup) before continuing.
 {: .notice--warning}
 
 If your previous CFW setup was EmuNAND-based and you wish to move the contents of your EmuNAND/RedNAND to SysNAND, follow [Move EmuNAND](move-emunand) before following this page. If you don't know what an EmuNAND is, this doesn't apply to you.


### PR DESCRIPTION
This PR reworks Finalizing Setup to (hopefully) make it easier to follow. The following changes have been made:

- The explanation of "valid arm9 payloads" run as `boot.firm` has been removed, as well as references to how SysNAND CFW bypasses the need for EmuNAND.
- The Move EmuNAND infobox has been moved to right before What You Need, and more explicitly says that it doesn't apply to most people.;
- The 2.1.0 CTRTransfer warning has been removed (I don't think an N3DS will even boot on 2.1 with boot9strap, and anyone in that situation would probably ask us for help anyway)
- "What You Need" has been split into three sections, depending on what the user is downloading (CIA files, 3DSX files, and "other")
    - Files are now in alphabetical order, both in What You Need and in Prep Work
- DSP1 is switched from 3DSX to CIA
- Prep Work has been condensed to include all file types in one step
- ctr-no-timeoffset and DSP1 have been combined into one step
- Explicit "Success" message at the very end
- Replace whatever was in "Information and Notes" before with an infobox containing keycombos, a link to the eiphax tips page, and a link to GodMode9 usage

Should be ready to merge, but any suggestions/tweaks/reversions are welcome.