### PR TITLE
Introduction V3 - mandatory version checking

### DIFF
--- a/_pages/en_US/checking-for-cfw.txt
+++ b/_pages/en_US/checking-for-cfw.txt
@@ -21,6 +21,7 @@ If your console has a menuhax based CFW setup, you should [clear Home Menu's ext
 1. You should now see a configuration menu of some sort
 
 ___
+### What to do next
 
 If your console boots to the normal home menu, return to [Get Started](get-started)
 {: .notice--success}

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -6,60 +6,63 @@ title: "Get Started"
 
 ### Required Reading
 
-If you have hacked your 3DS in the past, or you purchased your 3DS second-hand, it is possible that your console already has custom firmware. You should [check for CFW](checking-for-cfw) before proceeding.
+Before starting this guide, we will see if custom firmware is already is already installed and check the current system version of your device.
+
+#### Section I - CFW Check
+
+1. Power off your device
+1. Hold the (Select) button
+1. Power on your device while still holding the (Select) button
+1. If you do not see a configuration menu (e.g. "Luma3DS Configuration"), you may proceed to the next section
+
+If you see a configuration menu, STOP - you already have custom firmware! Continue from [here](checking-for-cfw#what-to-do-next).
 {: .notice--warning}
 
-Select the appropriate page for your version from the chart below. Note that the "from" and "to" fields are inclusive.
+#### Section II - System Version Check
 
-Your device version can be found at the bottom right of the top screen of the System Settings.
+1. Open the System Settings application
+1. Your system version will be displayed on the bottom right of the top screen (e.g. "Ver. 11.15.0-47U")
 
-![]({{ "/images/screenshots/system-version.png" | absolute_url }})
-{: .notice--info}
+#### Section III - Select a Method
 
-Before starting, you may want to check your SD card for errors using [H2testw (Windows)](h2testw-(windows)), [F3 (Linux)](f3-(linux)), or [F3XSwift (Mac)](f3xswift-(mac))!
-{: .notice--warning}
-
-While we believe that custom firmware is safe for online use, there have been online network bans in the past, primarily for cheating and suspicious eShop behavior.
-{: .notice--warning}
-
-### Version Table
-
-The letter and number after the system version (for example, 11.15.0-**47U**) is not relevant in this version table.
+Use the version table below to select a method. A few things to note:
+  + The version table below is *inclusive*. For example, "from 11.4.0 to 11.14.0" includes 11.4.0, 11.14.0, and all versions in between.
+  + Software versions do not work the same as decimals. Versions 11.10.0 and above are newer than 11.3.0, and are therefore not compatible with Soundhax.
+  + The number and letter after the system version are not important.
 
 <table>
   <colgroup>
-    <col span="1" style="width: 10%;">
-    <col span="1" style="width: 10%;">
+    <col span="1" style="width: 20%;">
     <col span="1" style="width: 40%;">
   </colgroup>
   <thead>
     <tr>
-      <th style="text-align: center">From</th>
-      <th style="text-align: center">To</th>
-      <th style="text-align: center">Action</th>
+      <th style="text-align: center">System Version</th>
+      <th style="text-align: center">What to do</th>
     </tr>
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: center; font-weight: bold;" colspan="2">11.15.0 (latest version)</td>
+      <td style="text-align: center; font-weight: bold;">11.15.0 (latest version)</td>
       <td style="text-align: center; font-weight: bold;"><a href="seedminer">Seedminer</a></td>
     </tr>
 	  <tr>
-      <td style="text-align: center; font-weight: bold;">11.4.0</td>
-      <td style="text-align: center; font-weight: bold;">11.14.0</td>
+      <td style="text-align: center; font-weight: bold;">11.4.0 to 11.14.0</td>
       <td style="text-align: center; font-weight: bold;">Update your 3DS to the latest version through System Settings</td>
     </tr>
     <tr>
-      <td style="text-align: center; font-weight: bold;">1.0.0</td>
-      <td style="text-align: center; font-weight: bold;">11.3.0</td>
+      <td style="text-align: center; font-weight: bold;">1.0.0 to 11.3.0</td>
       <td style="text-align: center; font-weight: bold;"><a href="installing-boot9strap-(soundhax)">Installing boot9strap (Soundhax)</a></td>
     </tr>
   </tbody>
 </table>
 
 ---
+#### Alternate Methods
 
-A number of methods that work on all versions are available, but require additional hardware. If possible, you should follow one of the software methods listed above instead.
+If possible, you should follow one of the software methods listed above.
+
+Otherwise, methods that work on all versions are available, but require additional hardware:
 
 1. [Installing boot9strap (kartdlphax)](installing-boot9strap-(kartdlphax)) - requires a 3DS with custom firmware and a copy of Mario Kart 7
 1. [ntrboot](ntrboot) - requires compatible DS flashcart

--- a/_pages/en_US/home.txt
+++ b/_pages/en_US/home.txt
@@ -10,10 +10,7 @@ excerpt: "A complete guide to 3DS custom firmware, <br /> from stock to boot9str
 ---
 
 Thoroughly read all of the introductory pages (including this one!) before proceeding.
-{: .notice--warning}
-
-The latest system software version is currently 11.15.0-47. If you have installed CFW in the past, it is highly recommended to follow [Checking for CFW](checking-for-cfw) to make sure your custom firmware is up-to-date.
-{: .notice--warning}
+{: .notice--info}
 
 ## What is custom firmware?
 
@@ -21,6 +18,7 @@ The latest system software version is currently 11.15.0-47. If you have installe
 
 Popular uses for custom firmware include:
 
+* Running homebrew software and games made for or ported to the Nintendo 3DS
 * Bypassing the region lock, allowing you to play games from other regions
 * Home menu customization, using community-created [themes and badges](https://themeplaza.art)
 * Modification of games ("ROM hacks") through [LayeredFS](https://github.com/knight-ryu12/godmode9-layeredfs-usage/wiki/Using-Luma3DS'-layeredfs-(Only-version-8.0-and-higher))
@@ -30,16 +28,22 @@ Popular uses for custom firmware include:
 
 ## What does this guide install?
 
-This guide will install **boot9strap + Luma3DS custom firmware** on **unmodified/stock** 3DS/2DS devices. If you have installed custom firmware in the past, you should follow [these instructions](checking-for-cfw) to find the correct upgrade path for your console. A modern, boot9strap/Luma3DS-based setup is preferred over older setups (arm9loaderhax, menuhax) because it is more stable for modern homebrew and continues to be supported by the community.
+This guide will:
+  + Install **boot9strap** and **Luma3DS custom firmware** on unmodified retail 3DS/2DS devices 
+    + Luma3DS will automatically remove the region lock and allow you to run unsigned software
+  + Install various pieces of homebrew software, such as a package installer, save file manager, and a homebrew app store
+  + Make critical system file backups that can help avoid bricks (and recover data in the event of one)
 
 ## What do I need to know before starting?
 
 * While the risks of bricking have been minimized over the years, **we are not responsible for anything that goes wrong with your device**. Incorrect file placement will not brick your device, but reckless behavior might.
-* This guide will work on every retail device in the Nintendo 3DS family of consoles (including the New 3DS series and the 2DS), regardless of region or firmware.
+* This guide is compatible with every retail device in the Nintendo 3DS family of consoles (including the New 3DS series and the 2DS), regardless of region or firmware.
 * Following this guide alone should not result in data loss, but SD card corruption is always a possibility. You should make a backup of your SD card contents if you have important data.
 * You will need a working SD card in your 3DS, as well as the ability to write files to the SD card. The 3DS can read SD cards formatted as MBR/FAT32.
+  + You may want to check your SD card for errors using [H2testw (Windows)](h2testw-(windows)), [F3 (Linux)](f3-(linux)), or [F3XSwift (Mac)](f3xswift-(mac)).
+* While we believe that custom firmware is safe for online use, there have been online network bans in the past, primarily for cheating and suspicious eShop behavior. 
 
 ___
 
-### Continue to [Get Started](get-started)
+## Continue to [Get Started](get-started)
 {: .notice--primary}


### PR DESCRIPTION
**Changes made in this PR:**

homepage: read intro warning -> info
homepage: remove cfw check notices, as it is now part of get-started
homepage: add homebrew software/ports as popular cfw use
homepage: revamp guide installation to describe everything the guide does
homepage: slight reword on device compatibility
homepage: add sd card error check and ban notice

get started: remove cfw check warning
get started: add mandatory cfw and system version check, using "section" structure
get started: remove sd card error check and ban notice (moved to homepage)
get started: convert "version table" to section
get started: add notes on what inclusivity means, how software decimals work
get started: table rework - switch from/to tables to "X to X" language; change "action" to "what to do"
get started: add header for alternate methods
get started: reword alternate methods note

checking-for-cfw: add header to link to from get-started

End result:
[homepage](https://user-images.githubusercontent.com/27717444/152485766-b414296d-aed4-4fae-bfa0-764184ab67dd.png)
[get started](https://user-images.githubusercontent.com/27717444/152485817-d6819f49-314f-4e1b-9ccf-d19c5c1b59c3.png)


