### PR TITLE
add twn seedminer method

### DIFF
--- a/_data/navigation/en_US.yml
+++ b/_data/navigation/en_US.yml
@@ -83,6 +83,9 @@ sidebar_pages:
     title: Homebrew Launcher (Soundhax)
     url: homebrew-launcher-(soundhax)
   -
+    title: BannerBomb3 + Fredtool (TWN)
+    url: bannerbomb3-fredtool-(twn)
+  -
     title: Installing boot9strap (Hardmod)
     url: installing-boot9strap-(hardmod)
   -
@@ -109,3 +112,4 @@ sidebar_pages:
   -
     title: Finalizing Setup
     url: finalizing-setup
+  

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -1,0 +1,157 @@
+---
+title: "BannerBomb3 + Fredtool (TWN)"
+---
+
+{% include toc title="Table of Contents" %}
+
+### Required Reading
+
+To dump system DSiWare, we exploit a flaw in the DSiWare Data Management window of the Settings application.
+
+To accomplish this, we use your system's encryption key (movable.sed) to build a DSiWare backup that exploits the system in order to dump the DSi Internet Settings application to the SD root.
+
+Once you have a DSiWare backup, an exploitable DSiWare title can be injected into DS Download Play, which can be used to install custom firmware.
+
+These instructions are for Taiwanese consoles ONLY (as indicated by a T at the end of the system version, e.g. 11.15.0-39T)! If your console is from any other region, [choose another method](seedminer#next-steps).
+{: .notice--warning}
+
+### What you need
+
+- Your `movable.sed` file completing [Seedminer](seedminer)
+- The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+- The latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest)
+- The latest release of [Frogminer_save](https://github.com/zoogie/Frogminer/releases/latest)
+
+#### Section I - CFW Check
+
+1. Power off your device
+1. Hold the (Select) button
+1. Power on your device while still holding the (Select) button
+1. If the check was successful, you will boot to the HOME Menu and you may proceed with this guide
+
+If you see a configuration menu, you already have CFW, and continuing with these instructions may BRICK your device! Follow [Checking for CFW](checking-for-cfw) to upgrade your existing CFW.
+{: .notice--danger}
+
+#### Section II - Prep Work
+
+1. Power off your device
+1. Insert your SD card into your computer
+1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card
+    + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
+1. Copy `boot.nds` (B9STool) to the root of your SD card
+1. Copy the `private` folder from the Frogminer_save `.zip` to the root of your SD card
+1. Keep your SD card in your computer - there are more things to do in the next section
+
+![]({{ "/images/screenshots/fredtool-root-layout.png" | absolute_url }})
+{: .notice--info}
+
+#### Section III - BannerBomb3
+
+1. Open the [DSIHaxInjector V2](https://jenkins.nelthorya.net/job/DSIHaxInjector%20v2/build?delay=0sec) website on your computer
+1. Under the "Username" field, enter any alphanumeric name (no spaces or special characters)
+1. Under the "MovableSed" field, upload your `movable.sed`using the "Browse..." option
+1. Click "Build"
+1. Wait a few seconds, then click "Last build (#number) x sec ago"
+1. Click the "output_(name).zip" link
+1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
+    +  `<ID0>` is the same as the one you used in Seedminer
+    + `<ID1>` is a 32-character folder inside of `<ID0>`
+    + If the `Nintendo DSiWare` folder does not exist, then create it
+1. If there is anything currently in the `Nintendo DSiWare` folder, move it elsewhere for safekeeping
+1. Open the output_(name) `.zip` file and navigate to `China_Taiwan` -> `output_setup`
+1. Copy all six `.bin` files to the `Nintendo DSiWare` folder
+1. Reinsert your SD card into your device
+1. Power on your device
+1. Launch System Settings on your device
+1. Navigate to `Data Management` -> `DSiWare` -> `SD Card` -> (page 2)
+1. Take note of what number is on the DSiWare title on the second page (it will be a number between 1 and 6)
+1. Power off your device
+1. Insert your SD card into your computer
+1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
+1. Open the output_(name) `.zip` file and navigate to `China_Taiwan` -> `output_hax`
+1. Copy the `.bin` file that is the same number as the one that was on the second page of the DSiWare Management menu to the `Nintendo DSiWare` folder, and overwrite when prompted
+1. Power on your device
+1. Launch System Settings on your device
+1. Navigate to `Data Management` -> `DSiWare` -> `SD Card`
+1. Wait a while
+     + The following should happen, in this order: A progress swirl, a short freeze, the bottom screen turning purple, the music stopping, then the devie showing an error message and rebooting
+    + If you did not see the purple screen or you saw a grey question mark icon, then something went wrong
+1. You should now have the file `42383821.bin` on the root of your SD card
+1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
+1. Delete all of the `.bin` files in the `Nintendo DSiWare` folder
+
+#### Section IV - Fredtool
+
+1. Open the [DSIHaxInjector_new](https://jenkins.nelthorya.net/job/DSIHaxInjector_new/build?delay=0sec) website on your computer
+1. Under the "Username" field, enter any alphanumeric name (no spaces or special characters)
+    + You might want to put in a different name to differentiate it from BannerBomb3's output
+1. Under the "DSiBin" field, upload your `42383821.bin` file using the first "Browse..." option
+1. Under the "MovableSed" field, upload your `movable.sed` file using the second "Browse..." option
+1. Under the "InjectionTarget" field, set the injection target to `DSdownloadplay`(NOT memorypit)
+1. Click "Build"
+1. Wait a few seconds, then click "Last build (#number) x sec ago"
+1. Click the "output_(name).zip" link
+1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
+1. Copy the `484E4441.bin`  file from the `hax` folder of the downloaded DSiWare archive (output_(name).zip) to the `Nintendo DSiWare` folder
+1. Reinsert your SD card into your device
+1. Power on your device
+1. Launch System Settings on your device
+1. Navigate to `Data Management` -> `DSiWare`
+1. Under the “SD Card” section, select the “Haxxxxxxxxx!” title
+1. Select “Copy”, then select “OK”
+1. Exit System Settings
+1. Launch Download Play on your device (the orange icon with a 3DS on it)
+1. Select "Nintendo DS" 
+1. If the exploit was successful, your 3DS will have loaded into the JPN version of Flipnote Studio
+
+#### Section V - Flipnote Exploit
+
+If you would prefer a visual guide to this section, one is available [here](https://zoogie.github.io/web/flipnote_directions/).
+{: .notice--info}
+
+1. Complete the initial setup process for the launched game until you reach the main menu
+  + Select the left option whenever prompted during the setup process
+1. Using the touch-screen, select the large left box, then select the box with an SD card icon
+1. Once the menu loads, select the face icon, then the bottom right icon to continue
+1. Press (X) or (UP) on the D-Pad depending on which is shown on the top screen
+1. Select the second button along the top with a film-reel icon
+1. Scroll right until reel "3/3" is selected
+1. Tap the third box with the letter "A" in it
+1. Scroll left until reel "1/3" is selected
+1. Tap the fourth box with the letter "A" in it
+1. If the exploit was successful, your device will have loaded b9sTool
+1. Using the D-Pad, move to “Install boot9strap”
+    + If you miss this step, the system will exit to home menu instead of installing boot9strap and you will need to open DS Download Play and start over from the beginning of this section
+1. Press (A), then press START and SELECT at the same time to begin the process
+1. Once completed and the bottom screen says “done.”, exit b9sTool, then power off your device
+    + You may have to force power off by holding the power button
+    + If you see the Luma Configuration screen, continue with the guide without powering off
+
+#### Section VI - Configuring Luma3DS
+
+1. Boot your device while holding (Select) to launch the Luma configuration menu
+    + If you encounter issues launching the Luma configuration menu, follow [this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
+    + If the blue light on your 3DS powers on and off, you are missing `boot.firm` from the root of your SD card
+1. Use the (A) button and the D-Pad to turn on the following:
+    + “Show NAND or user string in System Settings”
+1. Press (Start) to save and reboot
+
+#### Section VII - Restoring DS Download Play
+
+1. Power off your device
+1. Insert your SD card into your computer
+1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
+1. Copy the `484E4441.bin`  file from the `clean` folder of the downloaded DSiWare archive (output_(name).zip) to the `Nintendo DSiWare` folder
+1. Reinsert your SD card into your device
+1. Power on your device
+1. Launch System Settings on your device
+1. Navigate to `Data Management` -> `DSiWare`
+1. Under the “SD Card” section, select the “Haxxxxxxxxx!” title
+1. Select “Copy”, then select “OK”
+1. Exit System Settings
+1. Power off your device
+
+___
+
+### Continue to [Finalizing Setup](finalizing-setup)
+{: .notice--primary}

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -8,7 +8,7 @@ title: "BannerBomb3 + Fredtool (TWN)"
 
 To dump system DSiWare, we exploit a flaw in the DSiWare Data Management window of the Settings application.
 
-To accomplish this, we use your system's encryption key (movable.sed) to build a DSiWare backup that exploits the system in order to dump the DSi Internet Settings application to the SD root.
+To accomplish this, we use your system's encryption key (movable.sed) to build a DSiWare backup that exploits the system to dump the DSi Internet Settings application to the SD root.
 
 Once you have a DSiWare backup, an exploitable DSiWare title can be injected into DS Download Play, which can be used to install custom firmware.
 
@@ -74,8 +74,8 @@ If you see a configuration menu, you already have CFW, and continuing with these
 1. Launch System Settings on your device
 1. Navigate to `Data Management` -> `DSiWare` -> `SD Card`
 1. Wait a while
-     + The following should happen, in this order: A progress swirl, a short freeze, the bottom screen turning purple, the music stopping, then the devie showing an error message and rebooting
-    + If you did not see the purple screen or you saw a grey question mark icon, then something went wrong
+     + The following should happen, in this order: A progress swirl, a short freeze, the bottom screen turning purple, the music stopping, then the device showing an error message and rebooting
+    + If you did not see the purple screen, then something went wrong
 1. You should now have the file `42383821.bin` on the root of your SD card
 1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
 1. Delete all of the `.bin` files in the `Nintendo DSiWare` folder

--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -12,6 +12,9 @@ To accomplish this, we use your system's encryption key (movable.sed) to build a
 
 These instructions work on USA, Europe, Japan, and Korea region consoles as indicated by the letters U, E, J, or K after the system version.
 
+If you have a Taiwanese console (indicated by a T after the system version), follow [this page](bannerbomb3-fredtool-(twn)) instead.
+{: ..notice--warning}
+
 ### What You Need
 
 * Your `movable.sed` file from completing [Seedminer](seedminer)

--- a/_pages/en_US/seedminer.txt
+++ b/_pages/en_US/seedminer.txt
@@ -73,7 +73,16 @@ Continue to [Installing boot9strap (PicHaxx)](installing-boot9strap-(pichaxx))
 
 This method of using Seedminer for further exploitation uses your `movable.sed` file to take advantage of exploits in the SAFE_MODE firmware present in all 3DS units.
 
-This route is only recommended if you are for some reason unable to follow the PicHaxx + universal-otherapp route.
+This route is only recommended if you are for some reason unable to follow the PicHaxx + universal-otherapp route, such as lack of eShop access or using a Korean 3DS.
 
 Continue to [Installing boot9strap (USM)](installing-boot9strap-(usm))
+{: .notice--warning}
+
+___
+
+#### Taiwan consoles only
+
+If you have a Taiwanese device (indicated with a T at the end of the system version, such as 11.15.0-39**T**), you must follow this route. **Other regions may not follow this route.**
+
+Continue to [BannerBomb3 + Fredtool (TWN)](bannerbomb3-fredtool-(twn))
 {: .notice--warning}

--- a/_pages/en_US/site-navigation.txt
+++ b/_pages/en_US/site-navigation.txt
@@ -18,6 +18,7 @@ sitemap: false
 
 + [A9LH to B9S](a9lh-to-b9s)
 + [BannerBomb3](bannerbomb3)
++ [BannerBomb3 + Fredtool (TWN)](bannerbomb3-fredtool-(twn))
 + [Credits](credits)
 + [Checking for CFW](checking-for-cfw)
 + [Contribute](contribute)

--- a/assets/js/_main.js
+++ b/assets/js/_main.js
@@ -259,6 +259,7 @@ $(document).ready(function() {
       "11": ["seedminer", "installing-boot9strap-(usm)", "finalizing-setup"],
       "12": ["seedminer", "installing-boot9strap-(pichaxx)", "finalizing-setup"],
       "13": ["installing-boot9strap-(kartdlphax)", "finalizing-setup"],
+      "14": ["seedminer", "bannerbomb3-fredtool-(twn)", "finalizing-setup"],
     }
     // Can add custom routing if necessary but currently both routes are identical
     var device_old =  Object.assign({}, device_common,{


### PR DESCRIPTION
bb3-fred-twn: new page
bb3: add redirect for twn consoles
seedminer: add bb3-fred-twn method with clear indication and separation to show it is for twn consoles only
main.js: add bb3-fred-twn route
en_us nav: add bb3-fred-twn page
site-nav: add bb3-fred-twn page

Adding directly to guide rather than linking to gist for ease of translation. Hoping the separation and wording is clear enough that no non-TWN consoles will accidentally follow it.

May still need to be checked for 100% accuracy, but at least one person seems to have followed it without issue so far.
