### PR TITLE
fredtool: fix misleading to unneeded steps

### DIFF
--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -82,7 +82,7 @@ If you would prefer a visual guide to this section, one is available [here](http
 1. Tap the fourth box with the letter "A" in it
 1. If the exploit was successful, your device will have loaded b9sTool
 1. Using the D-Pad, move to "Install boot9strap"
-  + If you miss this step, the system will exit to HOME Menu instead of installing boot9strap and you will need to open Nintendo DS Connections and start over from the beginning of Section III
+  + If you miss this step, the system will exit to HOME Menu instead of installing boot9strap and you will need to open Nintendo DS Connections and start over from Step 12 of Section III
 1. Press (A), then press START and SELECT at the same time to begin the process
 1. Once completed and the bottom screen says "done.", exit b9sTool, then power off your device
   + You may have to force power off by holding the power button


### PR DESCRIPTION
The guide leads users to the beginning of Section III in case of misselecting in Step 11 of Section IV, but the files are already there, and the user simply needs to launch the exploit again. This pull request leads the users to the point where the user launches the System Settings.