### PR TITLE
Manually define colours for text selection

### DIFF
--- a/_sass/minimal-mistakes/_base.scss
+++ b/_sass/minimal-mistakes/_base.scss
@@ -6,6 +6,10 @@ html {
   /* sticky footer fix */
   position: relative;
   min-height: 100%;
+  ::selection {
+    color: $text-color;
+    background: $text-highlight-color;
+  }
 }
 
 body {

--- a/_sass/minimal-mistakes/skins/_nord.scss
+++ b/_sass/minimal-mistakes/skins/_nord.scss
@@ -257,6 +257,7 @@ $nord15: #b48ead;
 /* Colors */
 $background-color           : $nord0 !default;
 $text-color                 : $nord4 !default;
+$text-highlight-color       : $nord3 !default;
 $primary-color              : $nord8 !default;
 $success-color              : $nord14 !default;
 $warning-color              : $nord12 !default;


### PR DESCRIPTION
_Imagine using dark mode, couldn't be me_

**Description**

This minor edit to the CSS will allow for better text visibility when selecting a line of text anywhere on the guide. Users of dark mode would just see white text on white highlight.

Now they see white text on... a less white highlight. 

![](https://cdn.discordapp.com/attachments/761414751624101889/956191572754571334/unknown.png)
![](https://cdn.discordapp.com/attachments/761414751624101889/956191650693144597/unknown.png)
![](https://cdn.discordapp.com/attachments/761414751624101889/956191697195397150/unknown.png)