### PR TITLE
Enable ko_KR translation

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -206,7 +206,7 @@ exclude: [
   _pages/id_ID,
   # _pages/it_IT,
   # _pages/ja_JP,
-  _pages/ko_KR,
+  # _pages/ko_KR,
   _pages/ms_MY,
   _pages/no_NO,
   # _pages/nl_NL,

--- a/_includes/masthead.html
+++ b/_includes/masthead.html
@@ -68,7 +68,7 @@
           <!-- <li class="masthead__menu-item"><a href="{{ site.url }}/el_GR/{{ langless_url }}">Ελληνικά</a></li> -->
           <li class="masthead__menu-item"><a href="{{ site.url }}/he_IL/{{ langless_url }}">עברית‎</a></li>
           <!-- <li class="masthead__menu-item"><a href="{{ site.url }}/sv_SE/{{ langless_url }}">Svenska</a></li> -->
-          <!-- <li class="masthead__menu-item"><a href="{{ site.url }}/ko_KR/{{ langless_url }}">한국어</a></li> -->
+          <li class="masthead__menu-item"><a href="{{ site.url }}/ko_KR/{{ langless_url }}">한국어</a></li>
           <!-- <li class="masthead__menu-item"><a href="{{ site.url }}/no_NO/{{ langless_url }}">Norsk</a></li> -->
           <li class="masthead__menu-item"><a href="{{ site.url }}/ja_JP/{{ langless_url }}">日本語</a></li>
           <!-- <li class="masthead__menu-item"><a href="{{ site.url }}/ar_SA/{{ langless_url }}">اللغة العربية</a></li> -->


### PR DESCRIPTION
**Description**

ko_KR translations have translated and proofread the main guide path:

- home
- get started
- soundhax
- seedminer
- usm (only one string left because none of us have a KOR 3DS to figure it out)
- pichaxx
- fredtool
- finalizing setup

Fredtool for TWN was left untranslated.

This should be merged after the translations PR.