### PR TITLE
Add qBittorrent as client-recommendation

### DIFF
--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -10,7 +10,7 @@ This page is for existing arm9loaderhax users to update their devices to boot9st
 
 All future releases of Luma3DS will only be made in the `.firm` format, which will only be compatible with boot9strap and sighax. This means that to continue receiving the latest updates of Luma3DS, you should use this page to update your installation.
 
-To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 
 To extract the `.7z` files linked on this page, you will need a file archiver like [7-Zip](http://www.7-zip.org/) or [The Unarchiver](https://theunarchiver.com/).
 

--- a/_pages/en_US/ctrtransfer.txt
+++ b/_pages/en_US/ctrtransfer.txt
@@ -18,7 +18,7 @@ Performing a CTRTransfer may break extended memory mode games (Monster Hunter, S
 
 ### What You Need
 
-The CTRTransfer links require a torrent client to download, like [Deluge](http://dev.deluge-torrent.org/wiki/Download) or [qBitTorrent](https://www.qbittorrent.org/download.php).
+The CTRTransfer links require a torrent client to download, like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 {: .notice--warning}
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)

--- a/_pages/en_US/installing-boot9strap-(hardmod).txt
+++ b/_pages/en_US/installing-boot9strap-(hardmod).txt
@@ -10,7 +10,7 @@ An excellent guide to getting a hardmod can be found [here](https://gbatemp.net/
 
 This is a currently working implementation of the "FIRM partitions known-plaintext" exploit detailed [here](https://www.3dbrew.org/wiki/3DS_System_Flaws).
 
-To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 
 To extract the `.7z` files linked on this page, you will need a file archiver like [7-Zip](http://www.7-zip.org/) or [The Unarchiver](https://theunarchiver.com/).
 

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -6,7 +6,7 @@ title: "Installing boot9strap (ntrboot)"
 
 ### Required Reading
 
-To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 
 ### What You Need
 

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -31,7 +31,7 @@ Performing a region change may break extended memory mode games (Monster Hunter,
 
 ### What You Need
 
-The CTRTransfer links require a torrent client to download, like [Deluge](http://dev.deluge-torrent.org/wiki/Download) or [qBitTorrent](https://www.qbittorrent.org/download.php).
+The CTRTransfer links require a torrent client to download, like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download) or [qBitTorrent](https://www.qbittorrent.org/download.php).
 {: .notice--warning}
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -31,7 +31,7 @@ Performing a region change may break extended memory mode games (Monster Hunter,
 
 ### What You Need
 
-The CTRTransfer links require a torrent client to download, like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download) or [qBitTorrent](https://www.qbittorrent.org/download.php).
+The CTRTransfer links require a torrent client to download, like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 {: .notice--warning}
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)


### PR DESCRIPTION
**Description**

Added qBittorrent as torrent-client-recommendation considering Deluge hasn't got an official update for Windows or macOS in almost five years.
