### PR TITLE
Unify all magnet link notice text

### DIFF
--- a/_pages/en_US/ctrtransfer.txt
+++ b/_pages/en_US/ctrtransfer.txt
@@ -18,7 +18,7 @@ Performing a CTRTransfer may break extended memory mode games (Monster Hunter, S
 
 ### What You Need
 
-The CTRTransfer links require a torrent client to download, like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 {: .notice--warning}
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -31,7 +31,7 @@ Performing a region change may break extended memory mode games (Monster Hunter,
 
 ### What You Need
 
-The CTRTransfer links require a torrent client to download, like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
 {: .notice--warning}
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)


### PR DESCRIPTION
**Description**

Would prefer that there is only one string to translate. They all effectively say the same thing anyway.
