### PR TITLE
Correctness fixes for formatting MicroSD cards under Linux

### DIFF
--- a/_pages/en_US/formatting-sd-(linux).txt
+++ b/_pages/en_US/formatting-sd-(linux).txt
@@ -24,13 +24,13 @@ NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 mmcblk0     179:0    0   3,8G  0 disk
 └─mmcblk0p1 179:1    0   3,7G  0 part /run/media/user/FFFF-FFFF
 ```
-1. Take note of the device mount point. In our example above, it was `mmcblk0p1`
+1. Take note of the device name. In our example above, it was `mmcblk0p1`
   + If `RO` is set to 1, make sure the lock switch is not slid down
 1. Hit CTRL + C to exit the menu
 1. Type in the following for your SD card:
-    - 2GB or lower: `sudo mkfs.fat /dev/(device mount point from above) -s 64 -F 16` 
+    - 2GB or lower: `sudo mkfs.fat /dev/(device name from above) -s 64 -F 16` 
 	  - This creates a single FAT16 partition with 32 KB cluster size on the SD card
-    - 4GB - 128GB: `sudo mkfs.fat /dev/(device mount point from above) -s 64 -F 32` 
+    - 4GB - 128GB: `sudo mkfs.fat /dev/(device name from above) -s 64 -F 32` 
 	  - This creates a single FAT32 partition with 32 KB cluster size on the SD card
-    - 128GB or higher: `sudo mkfs.fat /dev/(device mount point from above) -s 128 -F 32`
+    - 128GB or higher: `sudo mkfs.fat /dev/(device name from above) -s 128 -F 32`
       - This creates a single FAT32 partition with 64 KB cluster size on the SD card

--- a/_pages/en_US/formatting-sd-(linux).txt
+++ b/_pages/en_US/formatting-sd-(linux).txt
@@ -24,7 +24,7 @@ NAME        MAJ:MIN RM   SIZE RO TYPE MOUNTPOINT
 mmcblk0     179:0    0   3,8G  0 disk
 └─mmcblk0p1 179:1    0   3,7G  0 part /run/media/user/FFFF-FFFF
 ```
-1. Take note of the device mount point. In our example above, it was `mmcblk0`
+1. Take note of the device mount point. In our example above, it was `mmcblk0p1`
   + If `RO` is set to 1, make sure the lock switch is not slid down
 1. Hit CTRL + C to exit the menu
 1. Type in the following for your SD card:


### PR DESCRIPTION
It's possible I missed something, but it looks like the existing instructions would have someone create a filesystem on top of the entire card instead of within the partition. This fixes that.