### PR TITLE
qol: improve what you need section

### DIFF
--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -10,8 +10,6 @@ This page is for existing arm9loaderhax users to update their devices to boot9st
 
 All future releases of Luma3DS will only be made in the `.firm` format, which will only be compatible with boot9strap and sighax. This means that to continue receiving the latest updates of Luma3DS, you should use this page to update your installation.
 
-To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
-
 To extract the `.7z` files linked on this page, you will need a file archiver like [7-Zip](http://www.7-zip.org/) or [The Unarchiver](https://theunarchiver.com/).
 
 While we believe that custom firmware is safe for online use, there have been online network bans in the past, primarily for cheating and suspicious eShop behavior.
@@ -19,16 +17,16 @@ While we believe that custom firmware is safe for online use, there have been on
 
 ### What You Need
 
-Note that the following required file named `secret_sector.bin` is the same one that was found in the various `data_input.zip` file versions. If you already have that file on your disk somewhere, you can use that one instead of downloading the one below.
-{: .notice--info}
+To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).
+{: .notice--warning}
 
 Note that, only on New 3DS, `secret_sector.bin` is needed to revert the arm9loaderhax exploit, which is why it is not needed for the installation of boot9strap on a stock console. If you do not have a New 3DS, you do not need `secret_sector.bin`.
 {: .notice--info}
 
 * <i class="fa fa-magnet" aria-hidden="true" title="This is a magnet link. Use a torrent client to download the file."></i> - **New 3DS Users Only:** [secret_sector.bin](magnet:?xt=urn:btih:15a3c97acf17d67af98ae8657cc66820cc58f655&dn=secret_sector.bin&tr=udp%3a%2f%2ftracker.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.lelux.fi%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.loadbt.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.moeking.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.monitorit4.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.ololosh.space%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.pomf.se%3a80%2fannounce&tr=udp%3a%2f%2ftracker.srv00.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.theoks.net%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.tiny-vps.com%3a6969%2fannounce&tr=udp%3a%2f%2fopen.tracker.cl%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.zerobytes.xyz%3a1337%2fannounce&tr=udp%3a%2f%2ftracker1.bt.moack.co.kr%3a80%2fannounce&tr=udp%3a%2f%2fvibe.sleepyinternetfun.xyz%3a1738%2fannounce&tr=udp%3a%2f%2fwww.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2fexodus.desync.com%3a6969%2fannounce&tr=http%3a%2f%2fopenbittorrent.com%3a80%2fannounce)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) 
-* The v7.0.5 release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/tag/v7.0.5) *(the `.7z` file)*
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
+* The v7.0.5 release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/tag/v7.0.5) (`Luma3DSv7.0.5.7z`)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip) 
 ### Instructions
 

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -18,9 +18,9 @@ These instructions are for Taiwanese consoles ONLY (as indicated by a T at the e
 ### What you need
 
 - Your `movable.sed` file completing [Seedminer](seedminer)
-- The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
-- The latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest)
-- The latest release of [Frogminer_save](https://github.com/zoogie/Frogminer/releases/latest)
+- The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
+- The latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest) (`boot.nds`)
+- The latest release of [Frogminer_save](https://github.com/zoogie/Frogminer/releases/latest) (`Frogminer_save.zip`)
 
 #### Section I - CFW Check
 

--- a/_pages/en_US/flashing-ntrboot-(3ds-multi-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-multi-system).txt
@@ -20,7 +20,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
   + **The source 3DS**: the 3DS family device that is already running boot9strap
   + **The target 3DS**: the device on stock firmware
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4-ntr.zip)
-* The latest release of [ntrboot_flasher](https://github.com/ntrteam/ntrboot_flasher/releases/latest)
+* The latest release of [ntrboot_flasher](https://github.com/ntrteam/ntrboot_flasher/releases/latest) (`ntrboot_flasher.firm`)
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
@@ -17,7 +17,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 * Your ntrboot compatible flashcart
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4-ntr.zip)
-* The latest release of [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest)
+* The latest release of [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest) (`ntrboot_flasher_nds.nds`)
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(dsi).txt
+++ b/_pages/en_US/flashing-ntrboot-(dsi).txt
@@ -19,7 +19,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 * Two devices 
   + **The source DSi**: the Nintendo DSi which is compatible with your flashcart
   + **The target 3DS**: the 3DS family device on stock firmware
-* The latest release of [ds_ntrboot_flasher](https://github.com/ntrteam/ds_ntrboot_flasher/releases/latest) *(`dsi` flasher; not the standard flasher)*
+* The latest release of [ds_ntrboot_flasher](https://github.com/ntrteam/ds_ntrboot_flasher/releases/latest) (`ds_ntrboot_flasher_dsi.nds`)
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(nds).txt
+++ b/_pages/en_US/flashing-ntrboot-(nds).txt
@@ -20,7 +20,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
   + **The source NDS / NDSL**: the Nintendo DS or Nintendo DS Lite which is compatible with your flashcart
   + **The target 3DS**: the 3DS family device on stock firmware
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4-ntr.zip) 
-* The latest release of [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest)
+* The latest release of [ntrboot_flasher_nds](https://github.com/jason0597/ntrboot_flasher_nds/releases/latest) (`ntrboot_flasher_nds.nds`)
 
 ### Instructions
 

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -12,11 +12,11 @@ This is a currently working implementation of the "FIRM partitions known-plainte
 
 ### What You Need
 
-* A DSiWare Backup (such as the one on SD root from [BannerBomb3](bannerbomb3))
+* A DSiWare Backup (You should have one on the root of your SD card from following [BannerBomb3](bannerbomb3))
 * Your `movable.sed` file from completing [Seedminer](seedminer)
-* The latest release of [Frogminer_save](https://github.com/zoogie/Frogminer/releases/latest)
-* The latest release of [b9sTool](https://github.com/zoogie/b9sTool/releases/latest)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+* The latest release of [Frogminer_save](https://github.com/zoogie/Frogminer/releases/latest) (`Frogminer_save.zip`)
+* The latest release of [b9sTool](https://github.com/zoogie/b9sTool/releases/latest) (`boot.nds`)
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
 
 #### Section I - CFW Check
 

--- a/_pages/en_US/installing-boot9strap-(hardmod).txt
+++ b/_pages/en_US/installing-boot9strap-(hardmod).txt
@@ -22,7 +22,7 @@ This will work on New 3DS, New 2DS, Old 3DS, and Old 2DS on *all* versions that 
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
 * The latest version of [hardmod-b9s-installer](https://github.com/ihaveamac/hardmod-b9s-installer/releases/latest)
   + Windows users can use the compiled `.exe`, while Mac and Linux users will need to have [Python 3](https://www.python.org/downloads/) installed to run the `.py`
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) 
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
 * The `.firm` corresponding to your device and version:
 
 | Version(s) | Kernel | Old 3DS or Old 2DS | New 3DS or New 2DS |

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -18,14 +18,14 @@ In order to follow these instructions, you will need the following:
 
 On the **source 3DS** (the 3DS with custom firmware):
 
-* The latest release of [kartdlphax](https://github.com/mariohackandglitch/kartdlphax/releases/latest)
-* The latest release of [Luma3DS 3GX Loader Edition](https://github.com/Nanquitas/Luma3DS/releases/latest)
+* The latest release of [kartdlphax](https://github.com/mariohackandglitch/kartdlphax/releases/latest) (`plugin.3gx`)
+* The latest release of [Luma3DS 3GX Loader Edition](https://github.com/Nanquitas/Luma3DS/releases/latest) (`boot.firm`)
 
 On the **target 3DS** (the 3DS that you are trying to modify):
 
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
-* The latest release of [standard Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+* The latest release of [standard Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file, not the source code)
 
 #### Section I - Prep Work (source 3DS)
 

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -12,9 +12,9 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 
 * A magnet that triggers the sleep mode of your device (if using a folding style device)
 * Your ntrboot flashed flashcart
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) 
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
 
 ### Instructions
 
@@ -90,7 +90,7 @@ Do not follow this section until you have completed the rest of the instructions
 
 ##### What You Need
 
-* The latest release of [ntrboot_flasher](https://github.com/ntrteam/ntrboot_flasher/releases/latest)
+* The latest release of [ntrboot_flasher](https://github.com/ntrteam/ntrboot_flasher/releases/latest) (`ntrboot_flasher.firm`)
 * The flashrom backup corresponding to your flashcart
   + Note that if you followed [Flashing ntrboot (3DS Multi System)](flashing-ntrboot-(3ds-multi-system)), the flashrom backup already exists in the correct location and does not need to be downloaded
   + Note that if you followed [Flashing ntrboot (3DS Single System)](flashing-ntrboot-(3ds-single-system)) or [Flashing ntrboot (NDS)](flashing-ntrboot-(nds)), the flashrom backup already exists on your flashcart's SD card and should be copied to the location specified below

--- a/_pages/en_US/installing-boot9strap-(pichaxx).txt
+++ b/_pages/en_US/installing-boot9strap-(pichaxx).txt
@@ -17,10 +17,10 @@ This process will overwrite your Pokémon Picross save file, if you have one. If
   + You can scan [this QR code](http://api.qrserver.com/v1/create-qr-code/?color=000000&bgcolor=FFFFFF&data=ESHOP://50010000037815&margin=0&qzone=1&size=400x400&ecc=L) using the Nintendo 3DS Camera for a direct link to the eShop app
   + Your SD card must be inserted in your device to install Pokémon Picross
 * Your `movable.sed` file from completing [Seedminer](seedminer)
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
-* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest)
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
+* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) (`otherapp.bin`)
 
 ### Instructions
 

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -12,10 +12,10 @@ Soundhax (when combined with universal-otherapp) is compatible with versions 1.0
 
 * The latest release of [Soundhax](http://soundhax.com) *(for your region, device, and version)*
   + If Soundhax appears in your browser as an unplayable video, press Ctrl+S or Cmd+S to save it to your computer
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
-* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest)
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
+* The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) (`otherapp.bin`)
 
 ### Instructions
 

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -22,9 +22,9 @@ If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, you will 
 ### What You Need
 
 * Your `movable.sed` file from completing [Seedminer](seedminer)
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
 
 
 #### Section I - Prep Work

--- a/_pages/en_US/updating-b9s.txt
+++ b/_pages/en_US/updating-b9s.txt
@@ -13,9 +13,9 @@ While we believe that custom firmware is safe for online use, there have been on
 
 ### What You Need
 
-* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
+* The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip)
-* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
+* The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
 
 ### Instructions
 


### PR DESCRIPTION
**Changes in this PR**
In the main “What You Need” sections:
- Switch SafeB9SInstaller to direct link
- Name files next to “the latest release” when possible (e.g., “The latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) (`otherapp.bin`)”)
- Move a9lh magnet link message to notice in what you need

Note: We're currently using “get the (x) file” in Finalizing Setup (e.g., “Get the `.cia` file”, “Get the GodMode9 `.zip` file”). Is this style of wording more user-friendly, or is it a bit repetitive? For consistency's sake, we should be using one or the other (having not decided yet, Finalizing Setup hasn't been modified at time of writing).

I'm also a bit iffy about the wording used for Luma3DS. In this PR, it's written as “the Luma3DS `.zip` file that isn't source code”, but if “Get the GodMode9 `.zip` file” is working fine in Finalizing Setup (that is, most people aren't trying to download the GM9 source code), then I think that would be better since it's less wordy.

