### PR TITLE
Guide update for Luma3DS v11.0

### DIFF
--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -63,12 +63,8 @@ For all steps in this section, overwrite any existing files on your SD card.
   + If you get an "OTP Crypto Fail" error, download <i class="fa fa-magnet" aria-hidden="true" title="This is a magnet link. Use a torrent client to download the file."></i> - [aeskeydb.bin](magnet:?xt=urn:btih:d25dab06a7e127922d70ddaa4fe896709dc99a1e&dn=aeskeydb.bin&tr=udp%3a%2f%2ftracker.tiny-vps.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.lelux.fi%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.loadbt.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.moeking.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.monitorit4.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.ololosh.space%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.pomf.se%3a80%2fannounce&tr=udp%3a%2f%2ftracker.srv00.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.theoks.net%3a6969%2fannounce&tr=udp%3a%2f%2fopen.tracker.cl%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.zerobytes.xyz%3a1337%2fannounce&tr=udp%3a%2f%2ftracker1.bt.moack.co.kr%3a80%2fannounce&tr=udp%3a%2f%2fvibe.sleepyinternetfun.xyz%3a1738%2fannounce&tr=udp%3a%2f%2fwww.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=http%3a%2f%2fopenbittorrent.com%3a80%2fannounce&tr=udp%3a%2f%2fexodus.desync.com%3a6969%2fannounce), then put it in the `/boot9strap/` folder on your SD card and try again
 1. When prompted, input the key combo given to install boot9strap
 1. Once it is complete, press (A) to reboot your device
-  + If your device shuts down on boot, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
-
-#### Section III - Configuring Luma3DS
-
-1. In the Luma3DS configuration menu, use the (A) button and the D-Pad to turn on the following:    
-  + **"Show NAND or user string in System Settings"**
+1. Your device should have rebooted into the Luma3DS configuration menu
+  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
 1. Press (Start) to save and reboot
 
 ___

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -136,9 +136,9 @@ If you would prefer a visual guide to this section, one is available [here](http
   + The existence of these folders and files confirms that Luma3DS is installed
   + If you do not see the `luma` folder or `config.ini`, [follow this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
 
 #### Section VII - Restoring DS Download Play
 

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -142,8 +142,6 @@ At this point, your console will boot to Luma3DS by default as long as the SD ca
 
 #### Section VII - Restoring DS Download Play
 
-1. Power off your device
-1. Insert your SD card into your computer
 1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card 
 1. Copy the `484E4441.bin`  file from the `clean` folder of the downloaded DSiWare archive (output_(name).zip) to the `Nintendo DSiWare` folder
 1. Reinsert your SD card into your device

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -128,7 +128,7 @@ If you would prefer a visual guide to this section, one is available [here](http
     + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
     + If you see the Luma Configuration screen, press (Start) to reboot, then continue with the guide
 
-#### Section V - Luma3DS Verification
+#### Section VI - Luma3DS Verification
 
 1. Power off your device
 1. Insert your SD card into your computer

--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -125,16 +125,20 @@ If you would prefer a visual guide to this section, one is available [here](http
 1. Press (A), then press START and SELECT at the same time to begin the process
 1. Once completed and the bottom screen says “done.”, exit b9sTool, then power off your device
     + You may have to force power off by holding the power button
-    + If you see the Luma Configuration screen, continue with the guide without powering off
+    + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
+    + If you see the Luma Configuration screen, press (Start) to reboot, then continue with the guide
 
-#### Section VI - Configuring Luma3DS
+#### Section V - Luma3DS Verification
 
-1. Boot your device while holding (Select) to launch the Luma configuration menu
-    + If you encounter issues launching the Luma configuration menu, follow [this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
-    + If the blue light on your 3DS powers on and off, you are missing `boot.firm` from the root of your SD card
-1. Use the (A) button and the D-Pad to turn on the following:
-    + “Show NAND or user string in System Settings”
-1. Press (Start) to save and reboot
+1. Power off your device
+1. Insert your SD card into your computer
+1. Verify that a `luma` folder exists and that `config.ini` is inside of it
+  + The existence of these folders and files confirms that Luma3DS is installed
+  + If you do not see the `luma` folder or `config.ini`, [follow this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
+
+At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+  + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
+  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
 
 #### Section VII - Restoring DS Download Play
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -132,11 +132,6 @@ These screenshots indicate the minimum SD card layout that is required to follow
   + If you get an error, make sure that you have at least 1.3GB of free space on your SD card
 1. Press (A) to continue
 1. Press (B) to return to the main menu
-1. Select "Dump Options"
-1. Select "Dump Boot9.bin & Boot11.bin"
-1. When prompted, press (A) to proceed
-1. Press (A) to continue
-1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted
 1. Navigate to `[S:] SYSNAND VIRTUAL`
@@ -147,10 +142,12 @@ These screenshots indicate the minimum SD card layout that is required to follow
 1. Press (Home) to bring up the action menu
 1. Select "Poweroff system" to power off your device
 1. Insert your SD card into your computer
-1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, `essential.exefs`, `<serialnumber>_boot9_###.bin`, and `<serialnumber>_boot11_###.bin` from the `/gm9/out/` folder on your SD card to a safe location on your computer
-  + Make backups in multiple locations (such as online file storage)
+1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
+1. Copy the `/luma/backups/` folder on your SD card to a safe location on your computer
+  + Copy these backups to multiple locations (such as online file storage, an external hard drive, etc.)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
+  + The other backup files are negligible in size and may be kept on your SD card for ease of access
 1. Reinsert your SD card into your device
 1. Power on your device
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -142,8 +142,8 @@ These screenshots indicate the minimum SD card layout that is required to follow
 1. Press (Home) to bring up the action menu
 1. Select "Poweroff system" to power off your device
 1. Insert your SD card into your computer
-1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
 1. Copy the `/luma/backups/` folder on your SD card to a safe location on your computer
+1. Copy `<date>_<serialnumber>_sysnand_###.bin`, `<date>_<serialnumber>_sysnand_###.bin.sha`, and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Copy these backups to multiple locations (such as online file storage, an external hard drive, etc.)
   + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
 1. Delete `<date>_<serialnumber>_sysnand_###.bin` and `<date>_<serialnumber>_sysnand_###.bin.sha` from the `/gm9/out/` folder on your SD card after copying it

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -97,9 +97,9 @@ If you would prefer a visual guide to this section, one is available [here](http
   + The existence of these folders and files confirms that Luma3DS is installed
   + If you do not see the `luma` folder or `config.ini`, [follow this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
 
 #### Section VI - Restoring DS Connection Settings
 

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -86,15 +86,16 @@ If you would prefer a visual guide to this section, one is available [here](http
 1. Press (A), then press START and SELECT at the same time to begin the process
 1. Once completed and the bottom screen says "done.", exit b9sTool, then power off your device
   + You may have to force power off by holding the power button
-  + If you see the Luma Configuration screen, continue with the guide without powering off
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
+  + If you see the Luma Configuration screen, press (Start) to reboot, then continue with the guide
 
-#### Section V - Configuring Luma3DS
+#### Section V - Luma3DS Verification
 
-1. Boot your device while holding (Select) to launch the Luma configuration menu
-  + If you encounter issues launching the Luma configuration menu, [follow this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
-1. Press (Start) to save and reboot
+1. Power off your device
+1. Insert your SD card into your computer
+1. Verify that a `luma` folder exists and that `config.ini` is inside of it
+  + The existence of these folders and files confirms that Luma3DS is installed
+  + If you do not see the `luma` folder or `config.ini`, [follow this troubleshooting guide](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md)
 
 At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
@@ -102,8 +103,6 @@ At this point, your console will boot to Luma3DS by default as long as the SD ca
 
 #### Section VI - Restoring DS Connection Settings
 
-1. Power off your device
-1. Insert your SD card into your computer
 1. Copy the `42383841.bin` file from the `output/clean/` folder of the downloaded DSiWare archive (`fredtool.zip`) to the `Nintendo 3DS/<ID0>/<ID1>/Nintendo DSiWare/` folder on your SD card
   + Replace the existing `42383841.bin` file
 1. Reinsert your SD card into your device

--- a/_pages/en_US/installing-boot9strap-(hardmod).txt
+++ b/_pages/en_US/installing-boot9strap-(hardmod).txt
@@ -87,9 +87,9 @@ This will work on New 3DS, New 2DS, Old 3DS, and Old 2DS on *all* versions that 
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
 
 ___
 

--- a/_pages/en_US/installing-boot9strap-(hardmod).txt
+++ b/_pages/en_US/installing-boot9strap-(hardmod).txt
@@ -82,13 +82,8 @@ This will work on New 3DS, New 2DS, Old 3DS, and Old 2DS on *all* versions that 
 1. Power off your device
 1. Disconnect your hardmod
 1. Power on your device
-
-#### Section III - Configuring Luma3DS
-
 1. Your device should have booted into the Luma3DS configuration menu
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -69,17 +69,13 @@ On the **target 3DS** (the 3DS that you are trying to modify):
 1. Wait a while (a percentage should be displayed on the **source 3DS**)
 1. If the exploit was successful, the **target 3DS** will have booted into SafeB9SInstaller
 
-#### Section IV - SafeB9SInstaller
+#### Section IV - Installing boot9strap
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it is complete, press (A) to reboot your device
-
-#### Section V - Configuring Luma3DS
-
 1. Your target 3DS should have rebooted into the Luma3DS configuration menu
-  + You can access the Luma3DS configuration menu at any time by powering off, holding SELECT, then powering on your device while still holding SELECT
-1. Use the (A) button and the D-Pad to turn on the following:
-  - **"Show NAND or user string in System Settings"**
+  + If your target 3DS shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
+1. Press (Start) to save and reboot
 
 At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -77,9 +77,9 @@ On the **target 3DS** (the 3DS that you are trying to modify):
   + If your target 3DS shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
   + You will **not** need to use your **source 3DS** to complete any further steps on this guide.
 
 ___

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -63,9 +63,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 1. Reinsert your SD card into your device
 1. Power on your device
 1. Your device should have booted into the Luma3DS configuration menu
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -67,9 +67,10 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
+
 
 ___
 

--- a/_pages/en_US/installing-boot9strap-(pichaxx).txt
+++ b/_pages/en_US/installing-boot9strap-(pichaxx).txt
@@ -72,14 +72,8 @@ This process will overwrite your Pokémon Picross save file, if you have one. If
 1. When prompted, input the key combo given on the top screen to install boot9strap
   + If the top screen is blank, reboot your device and re-launch Pokémon Picross
 1. Once it is complete, press (A) to reboot your device
-
-#### Section IV - Configuring Luma3DS
-
 1. Your device should have rebooted into the Luma3DS configuration menu
-  + You can access the Luma3DS configuration menu at any time by powering off, holding SELECT, then powering on your device while still holding SELECT
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
 
 At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.

--- a/_pages/en_US/installing-boot9strap-(pichaxx).txt
+++ b/_pages/en_US/installing-boot9strap-(pichaxx).txt
@@ -76,9 +76,10 @@ This process will overwrite your Pokémon Picross save file, if you have one. If
   + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
+
 
 At this point, Pokémon Picross is no longer necessary and can be removed from your device. If you wish to play the game, restore your `00000001.sav` backup or re-download the game from the Nintendo eShop.
 {: .notice--info}

--- a/_pages/en_US/installing-boot9strap-(safeb9sinstaller).txt
+++ b/_pages/en_US/installing-boot9strap-(safeb9sinstaller).txt
@@ -22,13 +22,8 @@ title: "Installing boot9strap (SafeB9SInstaller)"
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it is complete, press (A) to reboot your device
-
-#### Section III - Configuring Luma3DS
-
 1. Your device should have rebooted into the Luma3DS configuration menu
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 

--- a/_pages/en_US/installing-boot9strap-(safeb9sinstaller).txt
+++ b/_pages/en_US/installing-boot9strap-(safeb9sinstaller).txt
@@ -27,9 +27,10 @@ title: "Installing boot9strap (SafeB9SInstaller)"
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
+
 
 ___
 

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -65,9 +65,10 @@ Soundhax (when combined with universal-otherapp) is compatible with versions 1.0
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
+
 
 ___
 

--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -60,14 +60,8 @@ Soundhax (when combined with universal-otherapp) is compatible with versions 1.0
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it is complete, press (A) to reboot your device
-
-#### Section IV - Configuring Luma3DS
-
 1. Your device should have rebooted into the Luma3DS configuration menu
-  + You can access the Luma3DS configuration menu at any time by powering off, holding SELECT, then powering on your device while still holding SELECT
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
   + If you get an error, just continue to the next page
 

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -84,21 +84,15 @@ If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, you will 
 1. When prompted, input the key combo given on the top screen to install boot9strap
   + If the top screen is blank, power off your device and re-do Section III
 1. Once it is complete, press (A) to reboot your device
-
-#### Section V - Configuring Luma3DS
-
 1. Your device should have rebooted into the Luma3DS configuration menu
-  + You can access the Luma3DS configuration menu at any time by powering off, holding SELECT, then powering on your device while still holding SELECT
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
-1. Use the (A) button and the D-Pad to turn on the following:
-  + **"Show NAND or user string in System Settings"**
+  + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
 
 At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
   + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
 
-#### Section VI - Restoring WiFi Configuration Profiles
+#### Section V - Restoring WiFi Configuration Profiles
 
 1. Launch System Settings on your device
 1. Navigate to `Data Management` -> `DSiWare`

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -88,9 +88,9 @@ If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, you will 
   + If your device shuts down when you try to power it on, ensure that you have copied `boot.firm` from the Luma3DS `.zip` to the root of your SD card
 1. Press (Start) to save and reboot
 
-At this point, your console will boot to Luma3DS by default as long as the SD card is inserted.
+At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
-  + On the next page, you will copy Luma3DS to internal memory so that you can boot without an SD card.
+  + On the next page, you will install useful homebrew applications to complete your setup.
 
 #### Section V - Restoring WiFi Configuration Profiles
 

--- a/_pages/en_US/restoring-updating-cfw.txt
+++ b/_pages/en_US/restoring-updating-cfw.txt
@@ -25,7 +25,7 @@ Your SD card must be formatted as FAT32 to follow this guide, or else the 3DS wi
 1. Power on your device
   + If you see the Luma3DS configuration menu, press (Start) to save and reboot
 
-The latest version of Luma3DS has been installed on your SD card and on internal memory.
+The latest version of Luma3DS has now been installed on your SD card and on internal memory.
 {: .notice--success}
 ___
 

--- a/_pages/en_US/restoring-updating-cfw.txt
+++ b/_pages/en_US/restoring-updating-cfw.txt
@@ -12,11 +12,8 @@ Your SD card must be formatted as FAT32 to follow this guide, or else the 3DS wi
 
 ### What You Need
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest)
-* The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest)
 
 ### Instructions
-
-#### Section I - Prep Work
 
 1. Insert your SD card into your computer
 1. Copy `boot.3dsx` and `boot.firm` from the Luma3DS `.zip` to the root of your SD card, replacing any existing files
@@ -25,34 +22,8 @@ Your SD card must be formatted as FAT32 to follow this guide, or else the 3DS wi
   + If the `luma` or `payloads` folder doesn't exist, create them
 1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card, merging it with any existing folder and replacing any existing files
 1. Reinsert your SD card into your device
-
-#### Section II - Configuring Luma3DS
-
-1. Press and hold (Select), and while holding (Select), power on your device
-	* You should now see a Luma3DS configuration menu
-1. Use the (A) button and the D-Pad to turn on the following:
-	* **"Show NAND or user string in System Settings"**
-1. Press (Start) to save and reboot
-
-#### Section III - CTRNAND Luma3DS
-
-1. Power off your device
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-  + If you do not boot into GodMode9, ensure that GodMode9.firm is in `/luma/payloads/` and that `payloads` is correctly spelled
-1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
-1. Press (Home) to bring up the action menu
-1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Scripts from Plailect's Guide"
-1. Select "Setup Luma3DS to CTRNAND"
-  + This will copy the updated version of Luma3DS to internal memory so that your device will be able to boot without an SD card inserted
-1. When prompted, press (A) to proceed
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-1. Press (A) to continue
-1. Press (B), then navigate to "Exit" to exit GM9Megascript
-  + When prompted, relock write permissions
-1. Press (Home) to bring up the action menu
-1. Select "Poweroff system" to power off your device
+1. Power on your device
+  + If you see the Luma3DS configuration menu, press (Start) to save and reboot
 
 The latest version of Luma3DS has been installed on your SD card and on internal memory.
 {: .notice--success}

--- a/_pages/en_US/updating-b9s.txt
+++ b/_pages/en_US/updating-b9s.txt
@@ -50,15 +50,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card, replacing the existing file
 1. Reinsert your SD card into your device
 1. Power on your device
-
-#### Section IV - Configuring Luma3DS
-
-This section is only needed if you are prompted with the Luma3DS configuration menu after the reboot.
-{: .notice--info}
-
-1. In the Luma3DS configuration menu, use the (A) button and the D-Pad to turn on the following:    
-  + **"Show NAND or user string in System Settings"**
-1. Press (Start) to save and reboot
+1. If your device has booted into the Luma3DS configuration menu, press (Start) to save and reboot
 
 ___
 


### PR DESCRIPTION
This PR:

- B9S-*, AtoB, Updating-B9S: Merges the "Installing boot9strap" and "Configuring Luma3DS" sections when possible, as there is no longer anything necessary to configure in Luma3DS.
    - Because B9STool can (probably) still weirdly fail to install B9S sometimes, pages that use it (B9S-Fredtool and BB3-Fredtool-TWN) now have a "Luma3DS Verification" section that prompts people to check for the existence of the `luma` folder and `config.ini`. The next section has people do things on SD anyway, so it works out pretty well.
- B9S-*, AtoB, Updating-B9S: Rewords/clarifies the check for people who can't t boot because of missing `boot.firm`. (Not necessarily related to Luma 11, but useful for clarification purposes as we currently link to a pretty long troubleshooting page).
- B9S-kartdlphax: Renames "SafeB9SInstaller" section to "Installing boot9strap", in line with the rest of the guide.
- Finalizing: Removes boot9/boot11 backup, since Luma should do it now.
- Finalizing: Prompts people to backup `/luma/backups/`.
- Restoring-CFW: Removes Luma3DS configuration *and* GodMode9 Luma3DS to CTRNAND script instructions.
    - While the Luma3DS to CTRNAND script remains useful for troubleshooting purposes (since it copies GodMode9 to CTRNAND's payloads folder, making GodMode9 accessible when an SD is being fishy), it isn't strictly necessary for people that are restoring or updating CFW (since they should have already done that when following Finalizing Setup). Luma3DS to CTRNAND remains part of Finalizing Setup so people will still reasonably be getting GodMode9 to CTRNAND while we figure out what to do with the script situation.