### PR TITLE
add redirect plugin

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 gem "webrick", "~>1.7"
 gem "kramdown-parser-gfm", "~>1.1"
+gem "jekyll-redirect-from"
 gem "wdm", "~> 0.1.0" if Gem.win_platform?
 gemspec

--- a/_config.yml
+++ b/_config.yml
@@ -272,6 +272,7 @@ plugins:
   - jekyll-gist
   - jekyll-feed
   - jekyll-include-cache
+  - jekyll-redirect-from
 
 # mimic GitHub Pages with --safe
 whitelist:


### PR DESCRIPTION
Adds the [jekyll-redirect-from](https://github.com/jekyll/jekyll-redirect-from) plugin, which allows pages to be redirected.