### PR TITLE
Update guide for 11.16

### DIFF
--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -6,6 +6,9 @@ title: "BannerBomb3 + Fredtool (TWN)"
 
 ### Required Reading
 
+The instructions on this page do not currently work on the latest firmware (11.16.0). If you were directly linked to this page, [return to Seedminer](Seedminer) or join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{ .notice--warning}
+
 To dump system DSiWare, we exploit a flaw in the DSiWare Data Management window of the Settings application.
 
 To accomplish this, we use your system's encryption key (movable.sed) to build a DSiWare backup that exploits the system to dump the DSi Internet Settings application to the SD root.

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -4,11 +4,12 @@ title: "FAQ"
 {% include toc title="Table of Contents"%}
 
 {% capture notice-6 %}
-**The latest 3DS firmware is 11.15.0**. Here's what you should know:
+**3DS firmware 11.16.0 was recently released**. Here's what you should know:
 
 - If your device is running *Luma 10.2.1 or newer*, it is *100% safe* to update.
 - If your device is on an older Luma version, you should [update Luma](restoring-updating-cfw) before you update your device to 11.15.0.
-- No homebrew titles are known to have been affected by this update. They will work as they did on 11.14.0 and earlier.
+- [BootNTR Selector](https://github.com/Nanquitas/BootNTR/releases/latest) will need to be updated before it will work on 11.16.0.
+- If your device does not yet have custom firmware, you can still install it on this version for free without any additional hardware, but the methods have slightly changed.
 {% endcapture %}
 
 <div class="notice--warning">{{ notice-6 | markdownify }}</div>
@@ -16,7 +17,7 @@ title: "FAQ"
 ## Pre-Installation FAQ
 
 #### **Q:** *I am on the latest system version. Is my device hackable without any external hardware?*    
-**A:** Yes! The latest firmware (11.15.0) has a free method for getting CFW named [Seedminer](seedminer).
+**A:** Yes! The latest firmware (11.16.0) has a free method for getting CFW named [Seedminer](seedminer).
 
 #### **Q:** *What devices is this guide compatible with?*    
 **A:** The instructions are the same for all retail 3DS, 3DS XL, 2DS, New 3DS, New 3DS XL, and New 2DS XL devices. If your system version string displays as "0.0.0-0", then you may have a developer unit.

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -6,10 +6,10 @@ title: "FAQ"
 {% capture notice-6 %}
 **3DS firmware 11.16.0 was recently released**. Here's what you should know:
 
-- If your device is running *Luma 10.2.1 or newer*, it is *100% safe* to update.
-- If your device is on an older Luma version, you should [update Luma](restoring-updating-cfw) before you update your device to 11.15.0.
-- [BootNTR Selector](https://github.com/Nanquitas/BootNTR/releases/latest) will need to be updated before it will work on 11.16.0.
-- If your device does not yet have custom firmware, you can still install it on this version for free without any additional hardware, but the methods have slightly changed.
+- If your device is running *Luma 11.0*, it is *100% safe* to update. You can check your Luma version by holding (Select) while booting your device.
+- If your device is on an older Luma version, you should [update Luma](checking-for-cfw) before you update your device to 11.16.0.
+- [BootNTR Selector](https://github.com/Nanquitas/BootNTR/releases/latest) (used for running PLG plugins and wireless streaming) will need to be updated before it will work on 11.16.0. If you use it, you may want to wait for it to be updated before you update your device to 11.16.0.
+- If your device does not yet have custom firmware, you can still install it on this version for free without any additional hardware, but the recommended method has been changed.
 {% endcapture %}
 
 <div class="notice--warning">{{ notice-6 | markdownify }}</div>

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -19,12 +19,12 @@ If you see an unusual menu, STOP - you already have custom firmware! Continue fr
 #### Section II - System Version Check
 
 1. Open the System Settings application
-1. Your system version will be displayed on the bottom right of the top screen (e.g. "Ver. 11.15.0-47U")
+1. Your system version will be displayed on the bottom right of the top screen (e.g. "Ver. 11.16.0-48U")
 
 #### Section III - Select a Method
 
 Use the version table below to select a method. A few things to note:
-  + The version table below is *inclusive*. For example, "from 11.4.0 to 11.14.0" includes 11.4.0, 11.14.0, and all versions in between.
+  + The version table below is *inclusive*. For example, "from 11.4.0 to 11.15.0" includes 11.4.0, 11.15.0, and all versions in between.
   + Software versions do not work the same as decimals. Versions 11.10.0 and above are newer than 11.3.0, and are therefore not compatible with Soundhax.
   + The number and letter after the system version are not important.
   + No matter the method you follow, the end result is the same (boot9strap+Luma3DS custom firmware setup on the latest firmware).
@@ -42,11 +42,11 @@ Use the version table below to select a method. A few things to note:
   </thead>
   <tbody>
     <tr>
-      <td style="text-align: center; font-weight: bold;">11.15.0 (latest version)</td>
+      <td style="text-align: center; font-weight: bold;">11.16.0 (latest version)</td>
       <td style="text-align: center; font-weight: bold;"><a href="seedminer">Seedminer</a></td>
     </tr>
 	  <tr>
-      <td style="text-align: center; font-weight: bold;">11.4.0 to 11.14.0</td>
+      <td style="text-align: center; font-weight: bold;">11.4.0 to 11.15.0</td>
       <td style="text-align: center; font-weight: bold;">Update your 3DS to the latest version through System Settings</td>
     </tr>
     <tr>
@@ -63,6 +63,5 @@ If possible, you should follow one of the software methods listed above.
 
 Otherwise, methods that work on all versions are available, but require additional hardware:
 
-1. [Installing boot9strap (kartdlphax)](installing-boot9strap-(kartdlphax)) - requires a 3DS with custom firmware and a copy of Mario Kart 7
 1. [ntrboot](ntrboot) - requires compatible DS flashcart
 1. [Installing boot9strap (Hardmod)](installing-boot9strap-(hardmod)) - requires soldering

--- a/_pages/en_US/home.txt
+++ b/_pages/en_US/home.txt
@@ -9,8 +9,16 @@ header:
 excerpt: "A complete guide to 3DS custom firmware, <br /> from stock to boot9strap.<br />"
 ---
 
-11.16.0-48 was recently released. If you have installed CFW in the past, it is highly recommended to follow [Checking for CFW](checking-for-cfw) to make sure your custom firmware is up-to-date.
-{: .notice--warning}
+{% capture notice-6 %}
+**3DS firmware 11.16.0 was recently released**. Here's what you should know:
+
+- If your device is running *Luma 11.0*, it is *100% safe* to update. You can check your Luma version by holding (Select) while booting your device.
+- If your device is on an older Luma version, you should [update Luma](checking-for-cfw) before you update your device to 11.16.0.
+- [BootNTR Selector](https://github.com/Nanquitas/BootNTR/releases/latest) (used for running PLG plugins and wireless streaming) will need to be updated before it will work on 11.16.0. If you use it, you may want to wait for it to be updated before you update your device to 11.16.0.
+- If your device does not yet have custom firmware, you can still install it on this version for free without any additional hardware, but the recommended method has been changed.
+{% endcapture %}
+
+<div class="notice--warning">{{ notice-6 | markdownify }}</div>
 
 Thoroughly read all of the introductory pages (including this one!) before proceeding.
 {: .notice--info}

--- a/_pages/en_US/home.txt
+++ b/_pages/en_US/home.txt
@@ -9,6 +9,9 @@ header:
 excerpt: "A complete guide to 3DS custom firmware, <br /> from stock to boot9strap.<br />"
 ---
 
+11.16.0-48 was recently released. If you have installed CFW in the past, it is highly recommended to follow [Checking for CFW](checking-for-cfw) to make sure your custom firmware is up-to-date.
+{: .notice--warning}
+
 Thoroughly read all of the introductory pages (including this one!) before proceeding.
 {: .notice--info}
 

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -6,6 +6,9 @@ title: "Installing Boot9strap (Fredtool)"
 
 ### Required Reading
 
+The instructions on this page do not currently work on the latest firmware (11.16.0). If you were directly linked to this page, [return to Seedminer](Seedminer) or join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{ .notice--warning}
+
 This method of using Seedminer for further exploitation uses your `movable.sed` file to decrypt any DSiWare title for the purposes of injecting an exploitable DSiWare title into the DS Internet Settings application. This requires you to have a DSiWare backup, for example from BannerBomb or the DSiWare Dumper tool.
 
 This is a currently working implementation of the "FIRM partitions known-plaintext" exploit detailed [here](https://www.3dbrew.org/wiki/3DS_System_Flaws).

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -6,6 +6,9 @@ title: "Installing boot9strap (kartdlphax)"
 
 ### Required Reading
 
+The instructions on this page do not currently work on the latest firmware (11.16.0). If you were directly linked to this page, [return to Get Started](get-started) or join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{ .notice--warning}
+
 kartdlphax is an exploit for the Download Play mode of Mario Kart 7. It can be used with universal-otherapp to install custom firmware on target devices.
 
 In order to follow these instructions, you will need the following:

--- a/_pages/en_US/installing-boot9strap-(pichaxx).txt
+++ b/_pages/en_US/installing-boot9strap-(pichaxx).txt
@@ -6,6 +6,9 @@ title: "Installing boot9strap (PicHaxx)"
 
 ### Required Reading
 
+The instructions on this page do not currently work on the latest firmware (11.16.0). If you were directly linked to this page, [return to Seedminer](Seedminer) or join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{ .notice--warning}
+
 This method of using Seedminer for further exploitation uses your `movable.sed` file to write a custom save file for Pokémon Picross, which can then be used with universal-otherapp to run SafeB9SInstaller.
 
 This process will overwrite your Pokémon Picross save file, if you have one. If you wish to preserve your Pokémon Picross game data, you should make a backup of your `00000001.sav` file before overwriting it.

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -16,7 +16,7 @@ Once the WiFi profile has been injected, we will use SAFE_MODE, which is a recov
 
 These instructions work on USA, Europe, Japan, and Korea region consoles as indicated by the letters U, E, J, or K after the system version.
 
-If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, you will need to follow [an alternate branch of Seedminer](bannerbomb3). For assistance with this matter, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
 {: .notice--warning}
 
 ### What You Need

--- a/_pages/en_US/seedminer.txt
+++ b/_pages/en_US/seedminer.txt
@@ -59,31 +59,13 @@ ___
 
 ### Next Steps
 
-Once you have your device's encryption key (`movable.sed`), you will use it in conjunction with other exploits to install custom firmware on your 3DS. Select an exploit below.
+Once you have your device's encryption key (`movable.sed`), you will use it in conjunction with other exploits to install custom firmware on your 3DS.
 
-#### PicHaxx + universal-otherapp (Recommended)
-
-This method of using Seedminer for further exploitation uses your `movable.sed` file to write a custom save file for Pokémon Picross, which can then be used in conjunction with universal-otherapp to install custom firmware.
-
-This route requires the Pokémon Picross application (free on eShop), and thus requires eShop access and a 3DS with a region of USA, EUR, or JPN.
-
-Continue to [Installing boot9strap (PicHaxx)](installing-boot9strap-(pichaxx))
-{: .notice--primary}
-
-#### Installing boot9strap (unSAFE_MODE)
+#### unSAFE_MODE (Recommended)
 
 This method of using Seedminer for further exploitation uses your `movable.sed` file to take advantage of exploits in the SAFE_MODE firmware present in all 3DS units.
 
-This route is only recommended if you are for some reason unable to follow the PicHaxx + universal-otherapp route, such as lack of eShop access or using a Korean 3DS.
+You will need working shoulder buttons to use this method.
 
 Continue to [Installing boot9strap (USM)](installing-boot9strap-(usm))
-{: .notice--warning}
-
-___
-
-#### Taiwan consoles only
-
-If you have a Taiwanese device (indicated with a T at the end of the system version, such as 11.15.0-39**T**), you must follow this route. **Other regions may not follow this route.**
-
-Continue to [BannerBomb3 + Fredtool (TWN)](bannerbomb3-fredtool-(twn))
-{: .notice--warning}
+{: .notice--primary}


### PR DESCRIPTION
Updates guide for 11.16.

- Pages that require 11.16 and use universal-otherapp have been removed from the main guide path but still exist, with notices on the top in case of direct links.
- Pages that use b9stool (BB3+Fredtool/TWN) have been removed from the main guide path but still exist, with notices in case of direct links.
- unSAFE_MODE is the one and only recommended Seedminer method for now, with no changes required for 11.16.
- Notices for 11.16 added/updated on homepage and FAQ.
