### PR TITLE
kartdlphax: switch to using slotTool

### DIFF
--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -6,10 +6,7 @@ title: "Installing boot9strap (kartdlphax)"
 
 ### Required Reading
 
-The instructions on this page do not currently work on the latest firmware (11.16.0). If you were directly linked to this page, [return to Get Started](get-started) or join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
-{: .notice--warning}
-
-kartdlphax is an exploit for the Download Play mode of Mario Kart 7. It can be used with universal-otherapp to install custom firmware on target devices.
+kartdlphax is an exploit for the Download Play mode of Mario Kart 7. It can be used with unSAFE_MODE to install custom firmware on target devices.
 
 In order to follow these instructions, you will need the following:
 
@@ -28,7 +25,8 @@ On the **target 3DS** (the 3DS that you are trying to modify):
 
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip) (direct download)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip) (direct download)
-* The latest release of [standard Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file)
+* The latest release of [Luma3DS](https://github.com/AuroraWright/Luma3DS/releases/latest)
+* The latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/v1.3)
 
 #### Section I - Prep Work (source 3DS)
 
@@ -46,6 +44,9 @@ On the **target 3DS** (the 3DS that you are trying to modify):
 
 1. Insert the SD card of your **target 3DS** in your computer
 1. Copy `boot.firm` and `boot.3dsx` from the standard Luma3DS `.zip` to the root of your SD card
+1. Copy `usm.bin` from the unSAFE_MODE `.zip` to the root of your SD card
+1. Copy the otherapp payload for your region/version from the unSAFE_MODE `.zip`'s `otherapps_with_CfgS` folder and rename it to `otherapp.bin`
+1. Copy the `slotTool` folder from the unSAFE_MODE `.zip` to the `3ds` folder on your SD card
 1. Create a folder named `boot9strap` on the root of your SD card
 1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your SD card
 1. Copy `SafeB9SInstaller.bin` from the SafeB9SInstaller `.zip` to the root of your SD card
@@ -70,9 +71,29 @@ On the **target 3DS** (the 3DS that you are trying to modify):
 1. Select "Start" on the **source 3DS** once it has detected the **target 3DS**
 1. Once multiplayer has loaded, navigate to `Grand Prix` -> `50cc` -> (any driver) -> `Mushroom Cup` -> `OK`
 1. Wait a while (a percentage should be displayed on the **source 3DS**)
-1. If the exploit was successful, the **target 3DS** will have booted into SafeB9SInstaller
+1. If the exploit was successful, the **target 3DS** will have loaded the Homebrew Launcher
 
-#### Section IV - Installing boot9strap
+## Section IV - slotTool
+
+1. Launch slotTool from the list of homebrew
+  + If you get stuck on a red screen, delete `slotTool.xml` from the `/3ds/slotTool/` directory, then retry this section
+1. Select the "INSTALL exploit to wifi slots 1,2,3 & shutdown" option
+  + You will see some on-screen text and then your system will shut down
+
+#### Section V - unSAFE_MODE
+
+1. With your target 3DS still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), then press (Power)
+  + Keep holding the buttons until the device boots into Safe Mode
+1. Press "OK" to accept the update
+  + There is no update. This is part of the exploit
+1. Press "I accept" to accept the terms and conditions
+1. The update will eventually fail, with the error code `003-1099`. This is intended behaviour
+1. When asked "Would you like to configure Internet settings?", select "Yes"
+1. On the following menu, navigate to `Connection 1` -> `Change Settings` -> `Next Page (right arrow)` -> `Proxy Settings` -> `Detailed Setup`
+  + This is a [visual representation](https://uwuu.ca/images/safemode_highlighted.png)
+1. If the exploit was successful, your device will have booted into SafeB9SInstaller
+
+#### Section VI - Installing boot9strap
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
 1. Once it is complete, press (A) to reboot your device
@@ -84,6 +105,24 @@ At this point, your console will boot to Luma3DS by default.
   + Luma3DS does not look any different from the normal HOME Menu. If your console has booted into the HOME Menu, it is running custom firmware.
   + On the next page, you will install useful homebrew applications to complete your setup.
   + You will **not** need to use your **source 3DS** to complete any further steps on this guide.
+
+## Section VII - Restoring WiFi Configuration Profiles
+
+1. Launch the Download Play application
+1. Wait until you see the two buttons
+      + Do not press either of the buttons
+1. Press (Left Shoulder) + (D-Pad Down) + (Select) at the same time to open the Rosalina menu
+1. Select "Miscellaneous options"
+1. Select "Switch the hb. title to the current app."
+1. Press (B) to continue
+1. Press (B) to return to the Rosalina main menu
+1. Press (B) to exit the Rosalina menu
+1. Press (Home), then close Download Play
+1. Relaunch the Download Play application
+1. Your device should load the Homebrew Launcher
+1. Launch slotTool from the list of homebrew
+1. Select "RESTORE original wifi slots 1,2,3"
+1. Your device will then reboot
 
 ___
 


### PR DESCRIPTION
# Completely untested.

**Description**
universal-otherapp no longer works on NATIVE_FIRM. Switch to using slotTool -> USM.

In theory, this works. We got it working with PicHaxx, no reason for it to not work in kartdlphax.