### PR TITLE
*usm: clarify SAFE_MODE boot instructions

### DIFF
--- a/_pages/en_US/installing-boot9strap-(hbl-usm).txt
+++ b/_pages/en_US/installing-boot9strap-(hbl-usm).txt
@@ -12,6 +12,9 @@ As we already have Homebrew access, we can use slotTool to do this.
 
 Once the WiFi profile has been injected, we will use SAFE_MODE, which is a recovery feature present on all 3DS consoles, to activate the exploited WiFi profile.
 
+If your (Right/Left Shoulder), (D-Pad Up) or (A) buttons do not work, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{: .notice--danger}
+
 ### What You Need
 
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip) (direct download)
@@ -35,11 +38,9 @@ Once the WiFi profile has been injected, we will use SAFE_MODE, which is a recov
 
 #### Section II - unSAFE_MODE
 
-If your (Right/Left Shoulder), (D-Pad Up) or (A) buttons do not work, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
-{: .notice--danger}
-
-1. With your device still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), then press (Power)
+1. With your device still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), and while holding these buttons together, power on your device
   + Keep holding the buttons until the device boots into Safe Mode
+  + If you're unable to get into Safe Mode after multiple attempts, one of your buttons may be failing or broken. If this is the case, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
 1. Press "OK" to accept the update
   + There is no update. This is part of the exploit
 1. Press "I accept" to accept the terms and conditions

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -16,6 +16,9 @@ Once the WiFi profile has been injected, we will use SAFE_MODE, which is a recov
 
 These instructions work on USA, Europe, Japan, and Korea region consoles as indicated by the letters U, E, J, or K after the system version.
 
+If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, you will need to follow [an alternate branch of Seedminer](bannerbomb3). For assistance with this matter, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{: .notice--warning}
+
 ### What You Need
 
 * Your `movable.sed` file from completing [Seedminer](seedminer)
@@ -65,11 +68,9 @@ These instructions work on USA, Europe, Japan, and Korea region consoles as indi
 
 #### Section III - unSAFE_MODE
 
-If your (Right/Left Shoulder), (D-Pad Up), or (A) buttons do not work, you will need to follow [an alternate branch of Seedminer](bannerbomb3). For assistance with this matter, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
-{: .notice--warning}
-
-1. With your device still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), then press (Power)
+1. With your device still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), and while holding these buttons together, power on your device
   + Keep holding the buttons until the device boots into Safe Mode
+  + If you're unable to get into Safe Mode after multiple attempts, one of your buttons may be failing or broken. If this is the case, you will need to follow [an alternate branch of Seedminer](bannerbomb3). For assistance with this matter, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
 1. Press "OK" to accept the update
   + There is no update. This is part of the exploit
 1. Press "I accept" to accept the terms and conditions


### PR DESCRIPTION
**Description**
- Make it clear you need to keep holding while turning console on.
- Direct people to the above warning on broken buttons if this is suspected to be the cause of SAFE_MODE boot fail.
- Partially revert https://github.com/lifehackerhansol/Guide_3DS/commit/01edecf0ac5e05018e71ff11022883ba6aecae41
to bring button red warning back on top of page.

Thank you kind stranger for guide feedback.