### PR TITLE
add warning against installing old firm files

### DIFF
--- a/_pages/en_US/installing-boot9strap-(hardmod).txt
+++ b/_pages/en_US/installing-boot9strap-(hardmod).txt
@@ -25,6 +25,9 @@ This will work on New 3DS, New 2DS, Old 3DS, and Old 2DS on *all* versions that 
 * The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file that isn't source code)
 * The `.firm` corresponding to your device and version:
 
+The `.firm` for 11.16.0 needs a new nfirm, but we do not have a torrent set up yet: a hardmod with the old `.firm` WILL NOT WORK.
+{: .notice--warning}
+
 | Version(s) | Kernel | Old 3DS or Old 2DS | New 3DS or New 2DS |
 |-|-|:-:|:-:|
 | 1.0.0 | 2.27-0 | [2.27-0_1.0_OLD.firm](magnet:?xt=urn:btih:5c86edc67a1827991567b3c326a4182b66647d07&dn=2.27-0_1.0_OLD.firm&tr=udp%3a%2f%2fopen.tracker.cl%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce&tr=udp%3a%2f%2fexodus.desync.com%3a6969%2fannounce&tr=udp%3a%2f%2fwww.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.tiny-vps.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.pomf.se%3a80%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.moeking.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.dler.org%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.bitsearch.to%3a1337%2fannounce&tr=udp%3a%2f%2ftracker-udp.gbitt.info%3a80%2fannounce&tr=udp%3a%2f%2fretracker.netbynet.ru%3a2710%2fannounce&tr=udp%3a%2f%2fretracker.lanta-net.ru%3a2710%2fannounce&tr=udp%3a%2f%2fopentor.org%3a2710%2fannounce&tr=udp%3a%2f%2fopen.stealth.si%3a80%2fannounce&tr=udp%3a%2f%2fmts.tvbit.co%3a6969%2fannounce&tr=udp%3a%2f%2fexplodie.org%3a6969%2fannounce&tr=udp%3a%2f%2fbt2.archive.org%3a6969%2fannounce) | - |


### PR DESCRIPTION
**Description**

Hardmod firms for the `installing b9s - hardmod` page are not updated: this includes a warning to disuade readers from installing incorrect firmware until #2108 gets a torrent created.