### PR TITLE
clarify hardware button check

### DIFF
--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -53,8 +53,9 @@ In this section, you will test the SAFE_MODE function of your device. This will 
 1. With your device still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), and while holding these buttons together, power on your device
   + Keep holding the buttons until the device boots into Safe Mode (a "system update" menu)
 1. If prompted to update, press Cancel
+  + Your device will power off
   + If the device boots to the HOME Menu, just continue to the next step
-1. Power off your device
+1. If the device boots to the HOME Menu, power it off
 
 ___
 

--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -54,8 +54,7 @@ In this section, you will test the SAFE_MODE function of your device. This will 
   + Keep holding the buttons until the device boots into Safe Mode (a "system update" menu)
 1. If prompted to update, press Cancel
   + Your device will power off
-  + If the device boots to the HOME Menu, just continue to the next step
-1. If the device boots to the HOME Menu, power it off
+  + If the device boots to the HOME Menu, just power off your device
 
 ___
 


### PR DESCRIPTION
"I am in the hardware safe mode testing thing rn it prompted an update and after I pressed cancel it didn't go to the home menu it just shut off is this fine?"
"in this section of the guide my 3ds does go into the system update menu but doesn't go back to the main menu after I press the cancel button should I still do the safe mode method or the other one ?"
should fix these questions