### PR TITLE
faq+troubleshooting: collapsibles

### DIFF
--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -64,7 +64,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Your device should have rebooted into the Luma3DS configuration menu
   + Luma3DS configuration menu are settings for the Luma3DS custom firmware. Many of these settings may be useful for customization or debugging
   + For the purpose of this guide, these settings will be left on default settings
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#bboot-issues-on-devices-with-custom-firmware)
+  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-issues-on-devices-with-custom-firmware)
 1. Press (Start) to save and reboot
 
 ___

--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -64,7 +64,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Your device should have rebooted into the Luma3DS configuration menu
   + Luma3DS configuration menu are settings for the Luma3DS custom firmware. Many of these settings may be useful for customization or debugging
   + For the purpose of this guide, these settings will be left on default settings
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#boot-related-issues-on-modded-devices)
+  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#bboot-issues-on-devices-with-custom-firmware)
 1. Press (Start) to save and reboot
 
 ___

--- a/_pages/en_US/checking-for-cfw.txt
+++ b/_pages/en_US/checking-for-cfw.txt
@@ -10,7 +10,7 @@ This is an add-on section to check if your console already has a modern custom f
 
 If your console already has an arm9loaderhax or boot9strap based custom firmware, you will need to follow the instructions indicated to upgrade your setup to a modern one.
 
-If your console has a menuhax-based CFW setup, you should [clear HOME Menu's extdata](troubleshooting#clear-home-menu-extdata), then follow all instructions on your SysNAND. You probably have a menuhax-based setup if your system version when booting without an SD card is 9.2.0-20.
+If your console has a menuhax-based CFW setup, you should [clear HOME Menu's extdata](troubleshooting#other-troubleshooting), then follow all instructions on your SysNAND. You probably have a menuhax-based setup if your system version when booting without an SD card is 9.2.0-20.
 {: .notice--info}
 
 ### Instructions

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -14,79 +14,173 @@ title: "FAQ"
 
 ## Pre-Installation FAQ
 
-#### **Q:** *I am on the latest system version. Is my device hackable without any external hardware?*    
-**A:** Yes! The latest firmware (11.16.0) has a free method for getting CFW named [Seedminer](seedminer).
+{% capture compat %}
+<summary><u>I am on the latest system version. Is my device hackable without any external hardware?</u></summary>
 
-#### **Q:** *What devices is this guide compatible with?*    
-**A:** The instructions are the same for all retail 3DS, 3DS XL, 2DS, New 3DS, New 3DS XL, and New 2DS XL devices. If your system version string displays as "0.0.0-0", then you may have a developer unit.
+Yes! The latest firmware (11.16.0) has a free method for getting CFW named [Seedminer](seedminer).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *How risky is hacking my console?*    
-**A:** Bricks are now effectively impossible unless you are purposely trying to brick your device. 
+{% capture compat %}
+<summary><u>What devices is this guide compatible with?</u></summary>
 
-#### **Q:** *Can I run awesome homebrew and emulators with this?*    
-**A:** Yes! This guide will install a few useful homebrew applications, including [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest), which acts as a homebrew app store.
+The instructions are the same for all retail 3DS, 3DS XL, 2DS, New 3DS, New 3DS XL, and New 2DS XL devices. If your system version string displays as "0.0.0-0", then you may have a developer unit.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *Can I use this to play games from other regions?*    
-**A:** Yes; Luma3DS will automatically ignore the region check for cartridges and installed titles. Some games may need to make use of Luma's [locale emulation feature](https://github.com/LumaTeam/Luma3DS/wiki/Optional-features) in order to work properly on out-of-region devices.
+{% capture compat %}
+<summary><u>How risky is hacking my console?</u></summary>
 
-#### **Q:** *Will I lose any features if I install CFW?*    
-**A:** No. Devices with custom firmware can still use the eShop and run physical cartridges as any other 3DS can.
+Bricks are now effectively impossible unless you are purposely trying to brick your device. 
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *Can I keep my NNID?*    
-**A:** Your NNID (if you have one) will not be affected by this guide. Devices with a region of KOR, CHN, or TWN do not have NNID functionality to begin with and are thus unaffected.
+{% capture compat %}
+<summary><u>Can I run awesome homebrew and emulators with this?</u></summary>
 
-#### **Q:** *Will my 3DS be banned for having CFW?*    
-**A:** There was a ban wave in May 2017 that banned CFW users from online play (eShop access, NNIDs, and Nintendo Accounts were unaffected), seemingly at random. A ban wave at such a scale has not been seen since. That being said, we don't know what Nintendo may have in store in the future. At this time, we don't think that bans are something that you need to worry about.
+Yes! This guide will install a few useful homebrew applications, including [Universal-Updater](https://github.com/Universal-Team/Universal-Updater/releases/latest), which acts as a homebrew app store.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *Can I do this without a computer (e.g. an Android phone)?*    
-**A:** All you need is the ability to put files on a compatible SD card!
+{% capture compat %}
+<summary><u>Can I use this to play games from other regions?</u></summary>
 
-#### **Q:** *What size SD card can I use?*    
-**A:** You will need at least 1.5GB of free SD card space to follow this guide in its entirety. While the 3DS is officially compatible with SD cards up to 32GB, larger SD cards can be used if they are manually re-formatted as FAT32. It is not recommended to use SD cards greater than 128GB due to known issues with GBA graphics and custom themes.
+Yes; Luma3DS will automatically ignore the region check for cartridges and installed titles. Some games may need to make use of Luma's [locale emulation feature](https://github.com/LumaTeam/Luma3DS/wiki/Optional-features) in order to work properly on out-of-region devices.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *I heard about this thing I have to pay for (Gateway, Sky3DS, ntrboot, R4, etc). Is that something I need?*    
-**A:** No. Custom firmware can be installed for free on the latest firmware without any hardware devices. In fact, 3DS-mode flashcarts like Gateway and Sky3DS are not recommended because they are obsolete and may carry ban or brick risk.
+{% capture compat %}
+<summary><u>Will I lose any features if I install CFW?</u></summary>
 
-#### **Q:** *What's the difference between custom firmware and homebrew access?*    
-**A:** Historically, the 3DS used to have userland homebrew access through older exploits like ninjhax. The level of system access granted with userland allowed you to run basic homebrew and emulators but did not allow you to (easily) modify games or dump cartridges. It was also a lot less stable, with homebrew often ungracefully crashing and requiring a full reboot. Custom firmware grants a far greater level of system access while also being more stable than homebrew-only entrypoints.
+No. Devices with custom firmware can still use the eShop and run physical cartridges as any other 3DS can.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Can I keep my NNID?</u></summary>
+
+Your NNID (if you have one) will not be affected by this guide. Devices with a region of KOR, CHN, or TWN do not have NNID functionality to begin with and are thus unaffected.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Will my 3DS be banned for having CFW?</u></summary>
+
+There was a ban wave in May 2017 that banned CFW users from online play (eShop access, NNIDs, and Nintendo Accounts were unaffected), seemingly at random. A ban wave at such a scale has not been seen since. That being said, we don't know what Nintendo may have in store in the future. At this time, we don't think that bans are something that you need to worry about.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Can I do this without a computer (e.g. an Android phone)?</u></summary>
+
+Yes! All you need is the ability to put files on a compatible SD card.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>What size SD card can I use?</u></summary>
+
+You will need at least 1.5GB of free SD card space to follow this guide in its entirety. While the 3DS is officially compatible with SD cards up to 32GB, larger SD cards can be used if they are manually re-formatted as FAT32. It is not recommended to use SD cards greater than 128GB due to known issues with GBA graphics and custom themes.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>I heard about this thing I have to pay for (Gateway, Sky3DS, ntrboot, R4, etc). Is that something I need?</u></summary>
+
+No. Custom firmware can be installed for free on the latest firmware without any hardware devices. In fact, 3DS-mode flashcarts like Gateway and Sky3DS are not recommended because they are obsolete and may carry ban or brick risk.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>What's the difference between custom firmware and homebrew?</u></summary>
+
+Historically, the 3DS used to have userland homebrew access through older exploits like ninjhax. The level of system access granted with userland allowed you to run basic homebrew and emulators but did not allow you to (easily) modify games or dump cartridges. It was also a lot less stable, with homebrew often ungracefully crashing and requiring a full reboot. Custom firmware grants a far greater level of system access while also being more stable than homebrew-only entrypoints.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
 ## Post-Installation FAQ
 
-#### **Q:** *Is it safe to update my 3DS to the latest version with CFW?*    
-**A:** If you are using Luma3DS, your custom firmware loader (boot9strap) will *never* be removed when performing a system update. There have been updates in the past that have resulted in Luma3DS crashing on boot, so it is a good idea to wait a couple of hours to ensure that the latest update will not temporarily render the device unusable until Luma3DS is updated. System updates can be performed the same way as they are on a stock 3DS: through System Settings, Safe Mode, or the update prompt when the update is automatically downloaded.
+{% capture compat %}
+<summary><u>Is it safe to update my 3DS to the latest version with CFW?</u></summary>
 
-#### **Q:** *How do I upgrade my SD card?*    
-**A:** Copy and paste your SD card contents to a new SD card formatted as FAT32. For 128GB cards, an allocation size of 65536 is recommended. SD cards larger than 128GB are not recommended due to known issues with GBA graphics and custom themes.
+If you are using Luma3DS, your custom firmware loader (boot9strap) will *never* be removed when performing a system update. There have been updates in the past that have resulted in Luma3DS crashing on boot, so it is a good idea to wait a couple of hours to ensure that the latest update will not temporarily render the device unusable until Luma3DS is updated. System updates can be performed the same way as they are on a stock 3DS: through System Settings, Safe Mode, or the update prompt when the update is automatically downloaded.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *Can I system transfer with CFW?*    
-**A:** Yes, system transfers can be performed through the official System Transfer function to other consoles with CFW (inconsistencies may occur if the target console is stock). Tickets for illegitimate titles (homebrew) will not transfer, but the titles can be made to reappear with [faketik](https://github.com/ihaveamac/faketik/releases/latest). Make sure that you do not perform a wireless transfer, as this will delete illegitimate titles. CFW will remain on both consoles. 
+{% capture compat %}
+<summary><u>How do I upgrade my SD card?</u></summary>
 
-#### **Q:** *How do I change the system language of a Japanese 3DS?*    
-**A:** The only way to change the system language of a Japanese 3DS to a language other than Japanese is to perform a [region change](region-changing). Note that this is very likely to break the Nintendo eShop on your device, which means you will be unable to update your games whether they are in-region or out-of-region.
+Copy and paste your SD card contents to a new SD card formatted as FAT32. For 128GB cards, an allocation size of 65536 is recommended. SD cards larger than 128GB are not recommended due to known issues with GBA graphics and custom themes.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *How do I update homebrew applications?*    
-**A:** It depends on the format of the homebrew application. Generally speaking:
+{% capture compat %}
+<summary><u>Can I system transfer with CFW?</u></summary>
+
+Yes, system transfers can be performed through the official System Transfer function to other consoles with CFW (inconsistencies may occur if the target console is stock). Tickets for illegitimate titles (homebrew) will not transfer, but the titles can be made to reappear with [faketik](https://github.com/ihaveamac/faketik/releases/latest). Make sure that you do not perform a wireless transfer, as this will delete illegitimate titles. CFW will remain on both consoles.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>How do I change the system language of a Japanese 3DS?</u></summary>
+
+The only way to change the system language of a Japanese 3DS to a language other than Japanese is to perform a [region change](region-changing). Note that this is very likely to break the Nintendo eShop on your device, which means you will be unable to update your games whether they are in-region or out-of-region.
+ {% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>How do I update homebrew applications?</u></summary>
+
+It depends on the format of the homebrew application. Generally speaking:
 
 * Homebrew in **CIA format** can be updated by installing the new CIA, which will usually overwrite the old one. If the old CIA is not overwritten, you can delete the old one from Data Management as you would any other 3DS title.
 * Homebrew in **3DSX format** can be updated by replacing the 3DSX file in `/3ds/` with a fresh copy. If the homebrew application includes additional assets, you may need to place that folder somewhere else. Refer to the documentation of the homebrew application.
 * For updating Luma3DS, see [this page](restoring-updating-cfw). For updating GodMode9, see [this page](godmode9-usage#updating-godmode9).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *How do I update games from outside of my 3DS region?*    
-**A:** You will need to [dump the updates](dumping-titles-and-game-cartridges) from a 3DS that has the updates installed. The Nintendo eShop only contains updates for the console's region (a Japanese 3DS will only have updates for Japanese games).
+{% capture compat %}
+<summary><u>How do I update my games?</u></summary>
 
-#### **Q:** *Help! Something bad happened and now I cannot boot...*    
-**A:** Please look at the [troubleshooting guide](troubleshooting). **Uninstalling CFW when your device is in an unbootable state is not recommended, as it is very likely to lead to a brick**.
+You can continue to download game updates from the Nintendo eShop, even after the 2023 shutdown.
+
+If the game is not from the same region as the console, you will need to [dump the updates](dumping-titles-and-game-cartridges) from a 3DS that has the updates installed. The Nintendo eShop only contains updates for the console's region (a Japanese 3DS will only have updates for Japanese games).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Help! Something bad happened and my 3DS won't boot to HOME Menu...</u></summary>
+
+Please look at the [troubleshooting guide](troubleshooting#boot-issues-on-devices-with-custom-firmware). **Uninstalling CFW when your device is in an unbootable state is not recommended, as it is very likely to lead to a brick**.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
 ## menuhax / A9LH / Gateway FAQ
 
-#### **Q:** *I modded my device x years ago. What should I do?*    
-**A:** It is recommended that you upgrade your setup to a modern, boot9strap-based one. Follow the [Checking for CFW](checking-for-cfw) guide to see how to upgrade your setup.
+{% capture compat %}
+<summary><u>I modded my device (x) years ago, so it already has some sort of homebrew. What should I do?</u></summary>
 
-#### **Q:** *My setup works for me. Why should I upgrade it?*    
-**A:** The vast majority of modern homebrew (such as Checkpoint and BootNTR Selector) have only been tested on modern, boot9strap-based setups and may not work entirely (or at all) on older setups based on menuhax, A9LH, or Gateway. In addition, depending on your setup, you may be unable to safely update to the latest firmware. Modern, boot9strap-based setups allow for a greater level of system access than previous hacks, including the ability to dump your console's bootrom.
+It is recommended that you upgrade your setup to a modern, boot9strap-based one. Follow the [Checking for CFW](checking-for-cfw) guide to see how to upgrade your setup.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### **Q:** *Will I lose anything if I upgrade my setup?*    
-**A:** Your old setup (including your EmuNAND, if you have one) can usually be directly migrated to boot9strap with no data loss. If you have data that is particularly important to you, it would be a good idea to make a decrypted backup of your save data before upgrading your setup with a tool like [JKSM](https://github.com/J-D-K/JKSM/releases/tag/12%2F20%2F2018).
+{% capture compat %}
+<summary><u>My setup works for me. Why should I upgrade it?</u></summary>
 
-#### **Q:** *How do I move saves from an existing Gateway setup to a more modern setup?*    
+The vast majority of modern homebrew (such as Checkpoint and BootNTR Selector) have only been tested on modern, boot9strap-based setups and may not work entirely (or at all) on older setups based on menuhax, A9LH, or Gateway. In addition, depending on your setup, you may be unable to safely update to the latest firmware. Modern, boot9strap-based setups allow for a greater level of system access than previous hacks, including the ability to dump your console's bootrom.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Will I lose anything if I upgrade my setup?</u></summary>
+
+Your old setup (including your EmuNAND, if you have one) can usually be directly migrated to boot9strap with no data loss. If you have data that is particularly important to you, it would be a good idea to make a decrypted backup of your save data before upgrading your setup with a tool like [JKSM](https://github.com/J-D-K/JKSM/releases/tag/12%2F20%2F2018).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>How do I move saves from an existing Gateway setup to a more modern setup?</u></summary>
+
 **A:** See [this thread](https://gbatemp.net/threads/425743/).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -74,7 +74,7 @@ In this section, you will update your system to the latest version, which is saf
   + Updates while using B9S + Luma (what you have) are safe
   + The updater may display a message saying "Your system is up to date" instead of updating. This is normal if you are already up to date; continue with the next section
   + If this gives you an error, set both your DNS settings and Proxy settings to "auto"
-  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#unable-to-update-device)
+  + If this still gives you an error, [follow this troubleshooting guide](troubleshooting#finalizing-setup)
 
 #### Section III - Homebrew Launcher
 

--- a/_pages/en_US/installing-boot9strap-(fredtool).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool).txt
@@ -44,7 +44,7 @@ In this section, you will trigger the BannerBomb3 exploit using the DSiWare Mana
 1. Launch System Settings on your device
 1. Navigate to `Data Management` -> `DSiWare`-> `SD Card` ([image](/images/screenshots/bb3/dsiware-management.png))
   + Your device should show the BB3 multihax menu
-  + If this step causes your device to crash, [follow this troubleshooting guide](troubleshooting#dsiware-management-menu-crashes-without-showing-bb3-multihax-menu)
+  + If this step causes your device to crash, [follow this troubleshooting guide](troubleshooting#installing-boot9strap-fredtool)
 1. Use the D-Pad to navigate and press the (A) button to select "Dump DSiWare"
   + Your device will automatically reboot
 1. Power off your device

--- a/_pages/en_US/installing-boot9strap-(usm).txt
+++ b/_pages/en_US/installing-boot9strap-(usm).txt
@@ -63,7 +63,7 @@ In this section, you will trigger the BannerBomb3 exploit using the DSiWare Mana
 1. Launch System Settings on your device
 1. Navigate to `Data Management` -> `DSiWare`-> `SD Card` ([image](/images/screenshots/bb3/dsiware-management.png))
   + Your device should show the BB3 multihax menu
-  + If this step causes your device to crash, [follow this troubleshooting guide](troubleshooting#dsiware-management-menu-crashes-without-showing-bb3-multihax-menu)
+  + If this step causes your device to crash, [follow this troubleshooting guide](troubleshooting#bannerbomb3)
 1. Use the D-Pad to navigate and press the (A) button to select "Install unSAFE_MODE"
   + Your device will automatically power off
 

--- a/_pages/en_US/move-emunand.txt
+++ b/_pages/en_US/move-emunand.txt
@@ -168,7 +168,6 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 1. Reinsert your SD card into your device
 1. Press (A) to remount your SD card
 1. Press (Start) to reboot
-1. If you get a black screen, [follow this troubleshooting guide](troubleshooting#ts_sys_down)
 
 ___
 

--- a/_pages/en_US/seedminer.txt
+++ b/_pages/en_US/seedminer.txt
@@ -26,7 +26,7 @@ In this section, you will get the necessary details from your 3DS that are requi
   + If you don't have a `Nintendo 3DS` folder, put your SD card into your 3DS and power it on so that the folder can be created
 1. Copy the name of the 32-letter folder you see directly inside Nintendo 3DS
   + This 32-letter name is system-specific and will be different for each console
-  + If you see multiple 32-letter folders, follow [these instructions](troubleshooting#multiple-long-folder-names-in-nintendo-3ds-folder)
+  + If you see multiple 32-letter folders, follow [these instructions](troubleshooting#seedminer)
   + You can ignore the `private` folder if you have it
 
 	![]({{ "/images/screenshots/seedminer/id0-example.png" | absolute_url }})

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -2,37 +2,69 @@
 title: "Troubleshooting"
 ---
 
-{% include toc title="Table of Contents"%}
-
 This page offers troubleshooting advice for commonly encountered issues. If you are unable to solve your issue with the advice on this page, please join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and describe your issue, including what you have already tried.
 
----
+{% capture compat %}
+<summary>Table of Contents</summary>
+
+Used on multiple pages:
+* [SafeB9SInstaller](#issues-with-safeb9sinstaller)
+
+Guide pages:
+* [Seedminer](#seedminer)
+  * [BannerBomb3](#bannerbomb3)
+  * [Installing boot9strap (USM)](#installing-boot9strap-usm)
+  * [Installing boot9strap (Fredtool)](#installing-boot9strap-fredtool)
+  * [Homebrew Launcher (PicHaxx)](#homebrew-launcher-pichaxx)
+* [Installing boot9strap (Soundhax)](#installing-boot9strap-soundhax)
+* [Installing boot9strap (SSLoth-Browser)](#installing-boot9strap-ssloth-browser)
+
+* [Finalizing Setup](#finalizing-setup)
+
+Issues after installation:
+* [Boot issues](#boot-issues-on-devices-with-custom-firmware)
+* [Software issues](#software-issues-on-devices-with-custom-firmware)
+
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+{: .notice--info}
 
 ## Issues with SafeB9SInstaller
 
 ### SigHaxed FIRM was not installed! Check lower screen for more info.
 
-#### SigHaxed FIRM - File not found
+{% capture compat %}
+<summary><u>SigHaxed FIRM - File not found</u></summary>
 
 You are missing `boot9strap.firm` and `boot9strap.firm.sha` from the `boot9strap` folder, or the `boot9strap` folder is misnamed. Download the latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip), and place `boot9strap.firm` and `boot9strap.firm.sha` in the `boot9strap` folder.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### SigHaxed FIRM - invalid FIRM
+{% capture compat %}
+<summary><u>SigHaxed FIRM - invalid FIRM</u></summary>
 
 There is an issue with your `boot9strap.firm` and `boot9strap.firm.sha` files. Re-download the latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/download/1.4/boot9strap-1.4.zip), and place `boot9strap.firm` and `boot9strap.firm.sha` in the `boot9strap` folder.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### Secret Sector - File not found
+{% capture compat %}
+<summary><u>Secret Sector - File not found</u></summary>
 
 You are missing `secret_sector.bin` from the `boot9strap` folder, or the `boot9strap` folder is misnamed. Download [secret_sector.bin](magnet:?xt=urn:btih:15a3c97acf17d67af98ae8657cc66820cc58f655&dn=secret_sector.bin&tr=udp%3a%2f%2ftracker.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.lelux.fi%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.loadbt.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.moeking.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.monitorit4.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.ololosh.space%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.pomf.se%3a80%2fannounce&tr=udp%3a%2f%2ftracker.srv00.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.theoks.net%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.tiny-vps.com%3a6969%2fannounce&tr=udp%3a%2f%2fopen.tracker.cl%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.zerobytes.xyz%3a1337%2fannounce&tr=udp%3a%2f%2ftracker1.bt.moack.co.kr%3a80%2fannounce&tr=udp%3a%2f%2fvibe.sleepyinternetfun.xyz%3a1738%2fannounce&tr=udp%3a%2f%2fwww.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=udp%3a%2f%2fexodus.desync.com%3a6969%2fannounce&tr=http%3a%2f%2fopenbittorrent.com%3a80%2fannounce) using a torrent client, and place it in the `boot9strap` folder.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### Something else
+{% capture compat %}
+<summary><u>Something else</u></summary>
 
 Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance, and describe the message that you see.
-
----
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
 ## Seedminer
 
-### Multiple long folder names in Nintendo 3DS folder
+{% capture compat %}
+<summary><u>Multiple long folder names in Nintendo 3DS folder</u></summary>
 
 ![]({{ "/images/screenshots/multiple-id0.png" | absolute_url }})
 {: .notice--info}
@@ -49,98 +81,285 @@ This occurs when you use your SD card in multiple 3DS devices and is intended to
 	+ This is your true ID0 that you will use in [Section II of Seedminer](seedminer#section-ii---seedminer)
 1. Delete the `Nintendo 3DS` folder
 1. Rename the `BACKUP_Nintendo 3DS` folder to `Nintendo 3DS`
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Bruteforce Movable skips to step 4
+{% capture compat %}
+<summary><u>Bruteforce Movable skips to step 4</u></summary>
 
 The website has already mined your `movable.sed` using your friend code and ID0 combination. You can use the `movable.sed` that it provides you.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Important! You have been locked out of the automated part1 dumper system...
+{% capture compat %}
+<summary><u>Important! You have been locked out of the automated part1 dumper system...</u></summary>
 
 Your friend code was blocked from using the friend code bot because your 3DS did not successfully friend the bot. Ensure your 3DS is properly connected to the Internet, then join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask to be unlocked.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### We were unable to successfully complete your bruteforce request. :`(
+{% capture compat %}
+<summary><u>We were unable to successfully complete your bruteforce request. :`(</u></summary>
 
 The website has determined that your `movable.sed` cannot be brute-forced. Ensure that you gave the correct ID0 to the website. If your ID0 is correct, then you will be unable to use Seedminer and you will have to use an alternate method that will require additional games or hardware.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
----
+## BannerBomb3
 
-## Homebrew Launcher (PicHaxx)
+{% capture compat %}
+<summary><u>DSiWare Management menu crashes without showing BB3 multihax menu</u></summary>
+Ensure that `F00D43D5.bin` is the only file in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare`. If it is, then re-create it with the [Bannerbomb3 Injector](http://3dstools.nhnarwhal.com/#/bb3gen). 
 
-### "An error has occurred. Hold down the POWER button to turn off the power..." (black screen with text)
+Also, ensure that `bb3.bin` is on the root of the SD card. If it is missing, then download the latest release of [Bannerbomb3](https://github.com/lifehackerhansol/Bannerbomb3/releases/download/v3.0-lhs1/bb3.bin) (direct download), and copy the `bb3.bin` file to the root of your SD card.
 
-Your `00000001.sav` and/or `otherapp.bin` files may be misplaced. Ensure that `00000001.sav` is in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `title` -> `00040000` -> `0017c100` -> `data` and that `otherapp.bin` is on the root of your SD card.
+If neither of these solutions fixes this problem, then custom firmware may have been uninstalled on this device in a way that makes this method impossible to perform. If this is the case and Safe Mode works, you will need to follow [an alternate branch of Seedminer](homebrew-launcher-(pichaxx)). If Safe Mode doesn't work or you need assistance with this matter, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-If your files are in the correct locations, re-create the save using the [PicHaxx Save Tool](https://3dstools.nhnarwhal.com/#/pichaxx), then place it in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `title` -> `00040000` -> `0017c100` -> `data`. Ensure that the file is named exactly `00000001.sav` and that you used your console's `movable.sed` to create it. Re-download the latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/latest), place the `.bin` file relevant to your console from the `otherapps_with_CfgS` folder to the root of your SD card, and rename it to `otherapp.bin`. Do not add the `.bin` extension if you do not already see it.
+{% capture compat %}
+<summary><u>DSiWare Management menu does not crash</u></summary>
 
-### "An exception occurred" or Errdisp when opening Picross
+`F00D43D5.bin` is missing from `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare`. Make sure that `Nintendo DSiWare` is correctly spelled and spaced. Uppercase/lowercase does not matter.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-Your device already has custom firmware. You should [check for CFW](checking-for-cfw).
+{% capture compat %}
+<summary><u>DSiWare Management shows a question mark</u></summary>
 
-### "An error has occurred, forcing the software to close..." (white message box)
+There may be an issue with your `F00D43D5.bin` file (it may be corrupted or intended for the wrong 3DS). Re-create your `F00D43D5.bin` file with the [Bannerbomb3 Injector](http://3dstools.nhnarwhal.com/#/bb3gen), ensuring that you use the `movable.sed` file for your console.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-There is an issue with your `otherapp.bin` file. Download the latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/latest), place the `.bin` file relevant to your console from the `otherapps_with_CfgS` folder to the root of your SD card, and rename it to `otherapp.bin`. Do not add the `.bin` extension if you do not already see it.
+## Installing boot9strap (USM)
 
-### Game starts normally
+{% capture compat %}
+<summary><u>Safe Mode system update succeeds instead of giving error 003-1099</u></summary>
 
-Your modified `00000001.sav` file may be misplaced, or you may have used the wrong `movable.sed` when creating it. Re-generate your `movable.sed` from [Bruteforce Movable](https://seedminer.hacks.guide), then re-create the save using the [PicHaxx Save Tool](https://3dstools.nhnarwhal.com/#/pichaxx) and place the resulting file (`00000001.sav`) in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `title` -> `00040000` -> `0017c100` -> `data`.
+unSAFE_MODE is not installed. [Follow the instructions](installing-boot9strap-(usm)] to install it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
----
+{% capture compat %}
+<summary><u>Red screen after selecting "Detailed Setup"</u></summary>
 
-## Installing boot9strap (Soundhax)
+The file `usm.bin` is missing or misplaced. Download the latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/download/v1.3/usm.bin) and place `usm.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
 
-### Red/purple/pink and white screen after running Soundhax
+There is also a possibility that the console isn't reading your SD card. Make sure it is inserted and formatted correctly.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-If your device is on system version 9.4.0, 9.5.0, or 9.6.0, you may be encountering a bug with an old version of universal-otherapp. Download the latest version from [here](https://github.com/TuxSH/universal-otherapp/releases/latest).
-
-If your device is not on those firmwares, it likely indicates that you already have custom firmware. You should [check for CFW](checking-for-cfw).
-
-### "An error has occurred, forcing the software to close..." (white message box)
-
-There is an issue with your `otherapp.bin` file (it is missing, misplaced, or corrupted). Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) and place it on the root of your SD card.
-
-### "Could not play"
-
-You have the wrong Soundhax file for your device and region, or your device is incompatible with Soundhax. In the latter case, you should update your device to the latest version and follow [Seedminer](seedminer).
-
-### Failed to open SafeB9SInstaller.bin
+{% capture compat %}
+<summary><u>Failed to open SafeB9SInstaller.bin</u></summary>
 
 The file `SafeB9SInstaller.bin` is missing or misplaced. Download the latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip), extract it, and place `SafeB9SInstaller.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Failed to mount the SD card!
+{% capture compat %}
+<summary><u>Failed to mount the SD card!</u></summary>
 
 Back up your data and reformat your SD card as FAT32 with the recommended tool depending on your operating system ([Windows](formatting-sd-(windows)), [macOS](formatting-sd-(mac)), [Linux](formatting-sd-(linux))). MiniTool Partition Wizard and the HP formatting tool (HPUSBDisk) are known to cause issues with 3DS SD cards.
 
 If this is unsuccessful, try using another SD card.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
----
+## Installing boot9strap (Fredtool)
+
+{% capture compat %}
+<summary><u>Error on Fredtool Injector page</u></summary>
+
+Ensure that your `movable.sed` and DSiWare backup come from the same console. A mismatch will result in an error.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Unable to select "Haxxxxxxxxx!" because the BB3 multihax menu appears</u></summary>
+
+You forgot to delete `F00D43D5.bin` from the SD card. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card and delete the `F00D43D5.bin` file.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>"Haxxxxxxxxx!" does not appear</u></summary>
+
+There is an issue with your `42383821.bin` file (it is incorrect, missing, misplaced, or corrupted). Re-create your files with the [DSIHaxInjector_new](https://jenkins.nelthorya.net/job/DSIHaxInjector_new/build?delay=0sec) website and ensure that you place the `42383821.bin` file from `output.zip` -> `hax` in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare`.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>DS Connection Settings launches normally</u></summary>
+
+`Haxxxxxxxxx!` was not copied from your SD card to your system memory.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Black screen when launching DS Connection Settings</u></summary>
+
+Your DS Connection Settings application is broken, and you will need Homebrew Launcher access to fix this issue. Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>SD card is grayed out in Flipnote</u></summary>
+
+Flipnote may take a long time to index your card if you have a large SD card. Let it sit for a few minutes.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Lenny face does not appear in SD card section</u></summary>
+
+You did not copy the `private` folder from the Frogminer_save `.zip` to the root of your SD card.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Flipnote freezes</u></summary>
+
+You may have accidentally touched the touch screen while in the modified Flipnote. Re-enter DS Connection Settings and try again, ensuring that you don't accidentally use the touchscreen.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Green screen after pasting</u></summary>
+
+The file `boot.nds` is missing or misplaced. Download the latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest) and place `boot.nds` on the root of your SD card, replacing the existing one.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+
+{% capture compat %}
+<summary><u>White screen after pasting</u></summary>
+There is an issue with your `boot.nds` file. Re-download the latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest) and place `boot.nds` on the root of your SD card, replacing the existing one.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Unable to open Luma3DS configuration menu after running B9STool</u></summary>
+
+It is possible that boot9strap was not successfully installed. Follow section B of [this page](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+## Homebrew Launcher (PicHaxx)
+
+{% capture compat %}
+<summary><u>"An error has occurred. Hold down the POWER button to turn off the power..." (black screen with text)</u></summary>
+
+Your `00000001.sav` and/or `otherapp.bin` files may be misplaced. Ensure that `00000001.sav` is in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `title` -> `00040000` -> `0017c100` -> `data` and that `otherapp.bin` is on the root of your SD card.
+
+If your files are in the correct locations, re-create the save using the [PicHaxx Save Tool](https://3dstools.nhnarwhal.com/#/pichaxx), then place it in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `title` -> `00040000` -> `0017c100` -> `data`. Ensure that the file is named exactly `00000001.sav` and that you used your console's `movable.sed` to create it. Re-download the latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/latest), place the `.bin` file relevant to your console from the `otherapps_with_CfgS` folder to the root of your SD card, and rename it to `otherapp.bin`. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>"An exception occurred" or Errdisp when opening Picross</u></summary>
+
+Your device already has custom firmware. You should [check for CFW](checking-for-cfw).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>"An error has occurred, forcing the software to close..." (white message box)</u></summary>
+
+There is an issue with your `otherapp.bin` file. Download the latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/latest), place the `.bin` file relevant to your console from the `otherapps_with_CfgS` folder to the root of your SD card, and rename it to `otherapp.bin`. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Game starts normally</u></summary>
+
+Your modified `00000001.sav` file may be misplaced, or you may have used the wrong `movable.sed` when creating it. Re-generate your `movable.sed` from [Bruteforce Movable](https://seedminer.hacks.guide), then re-create the save using the [PicHaxx Save Tool](https://3dstools.nhnarwhal.com/#/pichaxx) and place the resulting file (`00000001.sav`) in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `title` -> `00040000` -> `0017c100` -> `data`.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+## Installing boot9strap (Soundhax)
+
+{% capture compat %}
+<summary><u>Red/purple/pink and white screen after running Soundhax</u></summary>
+
+If your device is on system version 9.4.0, 9.5.0, or 9.6.0, you may be encountering a bug with an old version of universal-otherapp. Download the latest version from [here](https://github.com/TuxSH/universal-otherapp/releases/latest).
+
+If your device is not on those firmwares, it likely indicates that you already have custom firmware. You should [check for CFW](checking-for-cfw).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>"An error has occurred, forcing the software to close..." (white message box)</u></summary>
+
+There is an issue with your `otherapp.bin` file (it is missing, misplaced, or corrupted). Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) and place it on the root of your SD card.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>"Could not play"</u></summary>
+
+You have the wrong Soundhax file for your device and region, or your device is incompatible with Soundhax. In the latter case, you should update your device to the latest version and follow [Seedminer](seedminer).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Failed to open SafeB9SInstaller.bin</u></summary>
+
+The file `SafeB9SInstaller.bin` is missing or misplaced. Download the latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip), extract it, and place `SafeB9SInstaller.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+
+{% capture compat %}
+<summary><u>Failed to mount the SD card!</u></summary>
+Back up your data and reformat your SD card as FAT32 with the recommended tool depending on your operating system ([Windows](formatting-sd-(windows)), [macOS](formatting-sd-(mac)), [Linux](formatting-sd-(linux))). MiniTool Partition Wizard and the HP formatting tool (HPUSBDisk) are known to cause issues with 3DS SD cards.
+
+If this is unsuccessful, try using another SD card.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
 ## Installing boot9strap (SSLoth-Browser)
 
-### Red/purple/pink and white screen after running browserhax
+{% capture compat %}
+<summary><u>Red/purple/pink and white screen after running Browserhax</u></summary>
 
 This likely indicates that you already have custom firmware. You should [check for CFW](checking-for-cfw).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### "An error has occurred. Hold down the POWER button to turn off the power..." (black screen with text)
+{% capture compat %}
+<summary><u>"An error has occurred. Hold down the POWER button to turn off the power..." (black screen with text)</u></summary>
 
 The file `arm11code.bin` is missing or misplaced. Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest), place `otherapp.bin` on the root of your SD card and rename it to `arm11code.bin`. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### "An error has occurred, forcing the software to close..." (white message box)
+
+{% capture compat %}
+<summary><u>"An error has occurred, forcing the software to close..." (white message box)</u></summary>
 
 There is an issue with your `arm11code.bin` file. Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest), place `otherapp.bin` on the root of your SD card and rename it to `arm11code.bin`. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Opening the browserhax QR code or URL crashes
+{% capture compat %}
+<summary><u>Opening the browserhax QR code or URL crashes</u></summary>
 
 Browser based exploits (such as this one) are often unstable and crash frequently, but they can sometimes be fixed by doing the following steps.
 
 1. Launch the browser, then launch the browser settings
 1. Scroll to the bottom and Initialize Savedata (it also may be called Clear All Save Data)
 1. Try the exploit again
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Opening the browser prompts for a system update instead
+{% capture compat %}
+<summary><u>System Update prompt when opening browser</u></summary>
 
 The SSLoth proxy was incorrectly configured. Re-do the SSLoth section on the page.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Error 032-0420 when trying to open the browser
+{% capture compat %}
+<summary><u>Error 032-0420 when opening browser</u></summary>
 
 Follow these steps in order:
 
@@ -157,126 +376,47 @@ Follow these steps in order:
 1. If prompted about a system update, press OK
   + This won't actually update the system
 1. Start again from [Section II](installing-boot9strap-(ssloth-browser).html#section-ii---ssloth)
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Failed to open SafeB9SInstaller.bin
+{% capture compat %}
+<summary><u>Failed to open SafeB9SInstaller.bin</u></summary>
 
 The file `SafeB9SInstaller.bin` is missing or misplaced. Download the latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip), extract it, and place `SafeB9SInstaller.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Frozen on "Doing agbhax..."
-
+{% capture compat %}
+<summary><u>Frozen on "Doing agbhax..."</u></summary>
 There may be an issue with your `arm11code.bin` file. Re-download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest), place it on the root of your SD card, and rename it to `arm11code.bin`. Do not add the `.bin` extension if you do not already see it.
 
 If you have a Taiwanese unit (with a T in the version string, ie. 11.3.0-##T), you will not be able to follow these instructions, and you will need to update your console and follow [Seedminer](seedminer) instead.
 
 If you have a Mainland Chinese unit (with a C in the version string, ie. 11.3.0-##C), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### "PrepareArm9ForTwl returned error c8804631!"
+{% capture compat %}
+<summary><u>"PrepareArm9ForTwl returned error c8804631!"</u></summary>
 
-You will need to follow an alternate method. Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Failed to mount the SD card!
-
-Back up your data and reformat your SD card as FAT32 with the recommended tool depending on your operating system ([Windows](formatting-sd-(windows)), [macOS](formatting-sd-(mac)), [Linux](formatting-sd-(linux))). MiniTool Partition Wizard and the HP formatting tool (HPUSBDisk) are known to cause issues with 3DS SD cards.
-
-If this is unsuccessful, try using another SD card.
-
----
-
-## BannerBomb3
-
-### DSiWare Management menu crashes without showing BB3 multihax menu
-
-Ensure that `F00D43D5.bin` is the only file in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare`. If it is, then re-create it with the [Bannerbomb3 Injector](http://3dstools.nhnarwhal.com/#/bb3gen). 
-
-Also, ensure that `bb3.bin` is on the root of the SD card. If it is missing, then download the latest release of [Bannerbomb3](https://github.com/lifehackerhansol/Bannerbomb3/releases/download/v3.0-lhs1/bb3.bin) (direct download), and copy the `bb3.bin` file to the root of your SD card.
-
-If neither of these solutions fixes this problem, then custom firmware may have been uninstalled on this device in a way that makes this method impossible to perform. If this is the case and Safe Mode works, you will need to follow [an alternate branch of Seedminer](homebrew-launcher-(pichaxx)). If Safe Mode doesn't work or you need assistance with this matter, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
-
-### DSiWare Management menu does not crash
-
-`F00D43D5.bin` is missing from `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare`. Make sure that `Nintendo DSiWare` is correctly spelled and spaced. Uppercase/lowercase does not matter.
-
-### DSiWare Management shows a question mark
-
-There may be an issue with your `F00D43D5.bin` file (it may be corrupted or intended for the wrong 3DS). Re-create your `F00D43D5.bin` file with the [Bannerbomb3 Injector](http://3dstools.nhnarwhal.com/#/bb3gen), ensuring that you use the `movable.sed` file for your console.
-
----
-
-## Installing boot9strap (USM)
-
-### Update doesn't fail with error code `003-1099`
-
-unSAFE_MODE is not installed. Follow the instructions on your page to install unSAFE_MODE again. 
-
-### Red screen when selecting detailed setup
-
-The file `usm.bin` is missing or misplaced. Download the latest release of [unSAFE_MODE](https://github.com/zoogie/unSAFE_MODE/releases/download/v1.3/usm.bin) and place `usm.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
-
-There is also a possibility that the console isn't reading your SD card. Make sure it is inserted and formatted correctly.
-
-### Failed to open SafeB9SInstaller.bin
-
-The file `SafeB9SInstaller.bin` is missing or misplaced. Download the latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip), extract it, and place `SafeB9SInstaller.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.
-
-### Failed to mount the SD card!
+{% capture compat %}
+<summary><u>Failed to mount the SD card!</u></summary>
 
 Back up your data and reformat your SD card as FAT32 with the recommended tool depending on your operating system ([Windows](formatting-sd-(windows)), [macOS](formatting-sd-(mac)), [Linux](formatting-sd-(linux))). MiniTool Partition Wizard and the HP formatting tool (HPUSBDisk) are known to cause issues with 3DS SD cards.
 
 If this is unsuccessful, try using another SD card.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
----
-
-## Installing boot9strap (Fredtool)
-
-### Error on Fredtool Injector page
-
-Ensure that your `movable.sed` and DSiWare backup come from the same console. A mismatch will result in an error.
-
-### Unable to select the "Haxxxxxxxxx!" title because of the BB3 multihax menu
-
-You forgot to delete `F00D43D5.bin` from the SD card. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card and delete the `F00D43D5.bin` file.
-
-### "Haxxxxxxxxx!" does not appear
-
-There is an issue with your `42383821.bin` file (it is incorrect, missing, misplaced, or corrupted). Re-create your files with the [DSIHaxInjector_new](https://jenkins.nelthorya.net/job/DSIHaxInjector_new/build?delay=0sec) website and ensure that you place the `42383821.bin` file from `output.zip` -> `hax` in `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare`.
-
-### DS Connection Settings launches normally
-
-`Haxxxxxxxxx!` was not copied from your SD card to your system memory.
-
-### Black screen when launching DS Connection Settings
-
-Your DS Connection Settings application is broken, and you will need Homebrew Launcher access to fix this issue. Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
-
-### SD card is grayed out
-
-Flipnote may take a long time to index your card if you have a large SD card. Let it sit for a few minutes.
-
-### Lenny face does not appear
-
-You did not copy the `private` folder from the Frogminer_save `.zip` to the root of your SD card.
-
-### Flipnote is frozen
-
-You may have accidentally touched the touch screen while in the modified Flipnote. Re-enter DS Connection Settings and try again, ensuring that you don't accidentally use the touchscreen.
-
-### Green screen after pasting 
-
-The file `boot.nds` is missing or misplaced. Download the latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest) and place `boot.nds` on the root of your SD card, replacing the existing one.
-
-### White screen after pasting
-
-There is an issue with your `boot.nds` file. Re-download the latest release of [b9stool](https://github.com/zoogie/b9sTool/releases/latest) and place `boot.nds` on the root of your SD card, replacing the existing one.
-
-### Unable to open Luma3DS configuration menu after running b9stool
-
-It is possible that boot9strap was not successfully installed. Follow section B of [this page](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md).
-
----
 
 ## Finalizing Setup
 
-### Unable to update device
+{% capture compat %}
+<summary><u>Unable to update device</u></summary>
 
 The steps below can be attempted in any order, but are listed from easiest to hardest to perform.
 
@@ -289,37 +429,41 @@ The steps below can be attempted in any order, but are listed from easiest to ha
 1. Nintendo servers may be down; Try again later
 1. If you still get an error, [follow CTRTransfer](ctrtransfer), then try again
 1. For further support (in English), join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Unable to enter Rosalina due to broken button(s)
+{% capture compat %}
+<summary><u>Unable to enter Rosalina menu due to broken Left Shoulder / Down D-Pad / Select button(s)</u></summary>
 
 Download this [alternate config.ini](https://cdn.discordapp.com/attachments/196635695958196224/982798396265988186/config.ini) and place it in `/luma/`. This will change the Rosalina key combination to (X) + (Y).
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### "An exception occurred" after trying to launch Homebrew Launcher via Download Play
+{% capture compat %}
+<summary><u>"An exception occurred" after trying to launch Homebrew Launcher from Download Play</u></summary>
 
 There is an issue with your `boot.3dsx` file (it is missing, misplaced, or corrupted). Download the latest release of [the Homebrew Launcher](https://github.com/devkitPro/3ds-hbmenu/releases/latest) and place `boot.3dsx` on the root of your SD card, replacing any existing file. Make sure you are extracting the ZIP file with any tool other than WinRAR, as it is known to cause issues with 3DS-related files.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### "Scripts directory not found" in GodMode9
+{% capture compat %}
+<summary><u>"Scripts directory not found" in GodMode9</u></summary>
 
 You did not copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card. Download the latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) and place the `gm9` folder on the root of your SD card, merging it with the existing one.
-
-### `essentials.exefs` missing from `/gm9/out/`
-
-Your device had custom firmware in the past, so you were not automatically prompted to make a backup. Make a backup manually:
-
-1. Reinsert your SD card into your device
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Navigate to `[S:] SYSNAND VIRTUAL`
-1. Select `essentials.exefs`, then `Copy to 0:/gm9/out/`
-1. You should now have `essentials.exefs` in `/gm9/out/`
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
 ---
 
-## Boot-related issues on modded devices
+## Boot issues on devices with custom firmware
 
 The steps detailed here generally assume that your device has a modern custom firmware setup (boot9strap + Luma3DS 8.0 or greater). If your console is running an older homebrew setup (for example, something based on arm9loaderhax or menuhax), you should update your setup before trying these instructions.
 {: .notice--info}
 
-### My device powers off when I try to turn it on, and/or the notification LED shows a color on boot
+### Power/notification light indicators
+
+{% capture compat %}
+<summary><u>My device powers off when I try to turn it on, and/or the notification LED shows a color on boot</u></summary>
 
 There is an issue with your `boot.firm` file. If you're running [boot9strap 1.4](https://github.com/SciresM/boot9strap/releases/tag/1.4), your 3DS notification LED may flash a certain color. This color is used to diagnose issues involving your `boot.firm` file on SD card or internal memory. On older versions of boot9strap, the blue light will power off almost immediately when trying to turn on the device.
 
@@ -332,11 +476,15 @@ If the notification LED flashes:
 You can get a new `boot.firm` file by downloading the [latest release of Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest), extracting it, and placing `boot.firm` on the root of your SD card. If your `boot.firm` file is consistently being detected as corrupted, you may want to check your SD card for errors ([Windows](h2testw-(windows)), [Linux](f3-(linux)), or [macOS](f3xswift-(mac))). Also, note that the 3DS tends to have issues with files extracted using WinRAR.
 
 If you hear a "popping sound", potentially accompanied with the backlight turning on for a split second, there is a hardware issue with your device (such as a disconnected backlight cable). You may be able to get your device to boot by holding it at certain angles.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### My device gets stuck on a black screen, with a static blue light
+{% capture compat %}
+<summary><u>My device gets stuck on a black screen with blue power light staying on</u></summary>
 
 The steps below can be attempted in any order, but are listed from least to most time-consuming.
 
+1. Power off your device, remove the SD card, re-insert it, then power on your device.
 1. Power off your device, eject the game cartridge if inserted, power on your device, then wait up to ten minutes. If your device boots within ten minutes, the issue has been fixed and is unlikely to reoccur
 1. Rename the `Nintendo 3DS` folder on your SD card to `Nintendo 3DS_BACKUP`, then attempt to boot. If your device successfully boots, there is some issue within your `Nintendo 3DS` folder. Try clearing HOME Menu extdata:
 	+ Navigate to `/Nintendo 3DS/<ID0>/<ID1>/extdata/00000000/`
@@ -354,35 +502,48 @@ The steps below can be attempted in any order, but are listed from least to most
 	+ If you were successful, the device will boot to an "update your system" screen
 1. Follow the [CTRTransfer](ctrtransfer) guide
 1. For further support, ask for help at [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp)
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### My device boots to an error screen
+### Error message on boot
 
-#### "An error has occurred: Failed to apply 1 FIRM patch(es)" or "An exception has occurred -- Current process: pm"
+{% capture compat %}
+<summary><u>"An error has occurred: Failed to apply 1 FIRM patch(es)" or "An exception has occurred -- Current process: pm"</u></summary>
 
 Your Luma3DS version is outdated. Download the latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) and place `boot.firm` on the root of your SD card, replacing any existing file. Make sure you are extracting the ZIP file with any tool other than WinRAR, as it is known to cause issues with 3DS-related files.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### "An error has occurred. Hold down the POWER button to turn off the power..."
+{% capture compat %}
+<summary><u>"An error has occurred. Hold down the POWER button to turn off the power..."</u></summary>
 
 ARM11 exception handlers are disabled, or custom firmware is not installed. Try enabling ARM11 exception handlers:
   + Power off your device
   + Hold (Select)
   + Power on your device, while still holding (Select)
   + If the "Disable ARM11 exception handlers" box is checked, uncheck it
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-#### Some other error
-
-Please take a photo of the error and join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
-
-### Blue "Bootrom Error" screen
+{% capture compat %}
+<summary><u>Blue "BOOTROM ERROR" screen</u></summary>
 
 Your device is likely hard-bricked. You will need to buy an ntrboot flashcart to reinstall boot9strap in order to attempt to fix your device. This may also indicate a hardware issue that cannot be fixed. In any case, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
   + It is also possible that someone has set a boot-time splash screen that just looks like a brick. Try leaving your device powered on, waiting on the blue screen, for five minutes.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
----
+{% capture compat %}
+<summary><u>Some other error</u></summary>
 
-## Functionality-related issues on modded devices
+Please take a photo of the error and join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### DSi / DS functionality is broken or has been replaced with Flipnote Studio
+## Software issues on devices with custom firmware
+
+{% capture compat %}
+<summary><u>DSi / DS functionality is broken or has been replaced with Flipnote Studio</u></summary>
 
 1. Download the latest release of [TWLFix-CFW](https://github.com/MechanicalDragon0687/TWLFix-CFW/releases/latest) (the `.3dsx` file)
 1. Power off your device
@@ -396,20 +557,29 @@ Your device is likely hard-bricked. You will need to buy an ntrboot flashcart to
 1. Perform a System Update by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
   + The update will see that the essential TWL titles have been uninstalled, and will redownload and reinstall them
 1. Once the update is complete, tap "OK" to reboot the device 
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### GBA Virtual Console and/or Safe Mode functionality is broken
+{% capture compat %}
+<summary><u>GBA Virtual Console and/or Safe Mode functionality is broken</u></summary>
 
-Your device is running Luma3DS/AuReiNand 6.6 or older, likely via arm9loaderhax. You should follow [A9LH to B9S](a9lh-to-b9s) to update your device to a modern custom firmware environment.
+Your device is running Luma3DS 6.6 or older, likely via arm9loaderhax. You should follow [A9LH to B9S](a9lh-to-b9s) to update your device to a modern custom firmware environment.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Extended memory mode games are broken
+{% capture compat %}
+<summary><u>Extended memory mode games (Pokemon Sun/Moon, Smash, etc.) don't work</u></summary>
 
 This can occur after a CTRTransfer or region change on Old 3DS / 2DS. You will need to system format your device to fix this issue.
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
 ---
 
 ## Other troubleshooting
 
-### Clear HOME Menu extdata
+{% capture compat %}
+<summary><u>Clear HOME Menu extdata</u></summary>
 
 1. Power off your device
 1. Insert your SD card into your computer
@@ -422,8 +592,11 @@ This can occur after a CTRTransfer or region change on Old 3DS / 2DS. You will n
   + **KOR Region**: `000000A9`
   + **TWN Region**: `000000B1`
 1. Reinsert your SD card into your device
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
 
-### Clear HOME Menu theme data
+{% capture compat %}
+<summary><u>Clear HOME Menu theme data</u></summary>
 
 1. Power off your device
 1. Insert your SD card into your computer
@@ -433,3 +606,6 @@ This can occur after a CTRTransfer or region change on Old 3DS / 2DS. You will n
   + **JPN Region**: `000002cc`
   + **USA Region**: `000002cd`
 1. Reinsert your SD card into your device
+{% endcapture %}
+<details>{{ compat | markdownify }}</details>
+

--- a/_pages/en_US/uninstall-cfw.txt
+++ b/_pages/en_US/uninstall-cfw.txt
@@ -59,7 +59,7 @@ The purpose of this section is to check whether built-in DS mode applications wi
   + If your console displays the Japanese version of Flipnote Studio, a black screen, or an error message, the test has failed
 1. Power off your device
 
-If either of these tests has failed, DS mode, DS Download Play, and/or DS Connection Settings may be inaccessible once CFW is uninstalled! You should [fix DS mode](troubleshooting#dsi--ds-functionality-is-broken-or-has-been-replaced-with-flipnote-studio) before continuing.
+If either of these tests has failed, DS mode, DS Download Play, and/or DS Connection Settings may be inaccessible once CFW is uninstalled! You should [fix DS mode](troubleshooting#software-issues-on-devices-with-custom-firmware) before continuing.
 {: .notice--warning}
 
 #### Section III - Safety Test


### PR DESCRIPTION
- Convert FAQ and Troubleshooting pages to clickable collapsibles to improve readability.
- Add separate table of contents to Troubleshooting (for mobile users)
- Remove a couple of irrelevant troubleshooting
- Update pages that link to troubleshooting to use new headers
