### PR TITLE
update troubleshooting for new b9stool

### DIFF
--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -240,7 +240,7 @@ There is an issue with your `boot.nds` file. Re-download the latest release of [
 {% capture compat %}
 <summary><u>Unable to open Luma3DS configuration menu after running B9STool</u></summary>
 
-It is possible that boot9strap was not successfully installed. Follow section B of [this page](https://github.com/zoogie/b9sTool/blob/master/TROUBLESHOOTING.md).
+Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and explain what has happened.
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 


### PR DESCRIPTION
If b9stool 7 was run and luma config did not boot, something unexpected and weird is going on. The old tactic of dry updating will not help, and manual assistance will be necessary to find a fix specific to what unexpected firm was installed.

Please wait to merge this until the new b9stool changes have been released. Also, I'm bad at wording things so if anyone wishes to reword this please do.
