### PR TITLE
Add includes for ctrtransfer steps

### DIFF
--- a/_pages/en_US/ctrtransfer.txt
+++ b/_pages/en_US/ctrtransfer.txt
@@ -41,86 +41,23 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 
 #### Section I - Prep Work
 
-1. Power off your device
-1. Insert your SD card into your computer
-1. Create a folder named `3ds` on the root of your SD card if it does not already exist
-1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
-1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card
-1. Copy the 11.15.0 CTRTransfer image `.bin` from the CTRTransfer `.zip` to the `/gm9/` folder on your SD card
-1. Copy `FBI.3dsx` to the `/3ds/` folder on your SD card
-1. Reinsert your SD card into your device
+{% include_relative include/ctrtransfer-prep.txt %}
 
 #### Section II - CTRTransfer
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
-1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
-  + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
-1. Navigate to `[0:] SDCARD` -> `gm9`
-1. Press (A) on the CTRTransfer `.bin` to select it
-1. Select "CTRNAND options..."
-1. Select "Transfer image to CTRNAND"
-1. If prompted, select "Transfer to SysNAND"
-  + This prompt will only appear if you have an EmuNAND
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-  + This process will take some time
-1. Once the transfer is completed, press (A) to continue
-1. Press (B) to decline relocking write permissions if prompted
-1. Press (B) twice to return to the main menu
-1. Press (Home) to bring up the action menu
-1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Scripts from Plailect's Guide"
-1. Select "CTRTransfer Ticket Copy"
-1. When prompted, press (A) to proceed
-1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
-1. Press (Start) to reboot your device
-1. Update your device by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
-  + Updates while using B9S + Luma (what you have) are safe
-  + If this gives you an error, set your DNS settings to "auto"
+{% include_relative include/ctrtransfer-main.txt %}
 
 #### Section III - Launching FBI
 
-1. Launch the Download Play application (this [icon]({{ "/images/download-play-icon.png" | absolute_url }}))
-1. Press (L) + (Down) + (Select) at the same time to open the Rosalina menu
-1. Select "Miscellaneous options"
-1. Select "Switch the hb. title to the current app."
-1. Press (B) to continue
-1. Press (B) to return to the Rosalina main menu
-1. Press (B) to exit the Rosalina menu
-1. Press (Home), then close Download Play
-1. Launch the Download Play application
-1. Your device should load the Homebrew Launcher
+{% include_relative include/launch-hbl-dlp.txt %}
 
 #### Section IV - Reinstalling Tickets
 
-If the script found no user tickets and told you to skip this section, you can skip this section.
-{: .notice--info}
-
-1. Launch FBI from the list of homebrew
-1. Select "SD"
-1. Select "gm9"
-1. Select "out"
-1. Select "ctrtransfer_tickets"
-1. Do the following process for either the `eshop` folder, `unknown` folder, or both
-  + Navigate to the folder
-  + Select "\<current directory>"
-  + Select "Install and delete all tickets"
-  + Wait. The system may appear to freeze, just give it time.
-  + Press (A) to confirm
-  + Press (B) to decline installing tickets from CDN.
-1. Press (Home) to exit FBI
+{% include_relative include/ctrtransfer-ticket-copy.txt %}
 
 #### Section V - Remove CTRTransfer image
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Navigate to `[0:] SDCARD` -> `gm9`
-1. Press (X) on the CTRTransfer image `.bin` to delete it
-1. Press (A) to confirm
-1. Press (Start) to reboot your device
+{% include_relative include/ctrtransfer-cleanup.txt %}
 
 ___
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -80,18 +80,7 @@ In this section, you will update your system to the latest version, which is saf
 
 In this section, you will temporarily replace Download Play with Homebrew Launcher (which we need to launch FBI). Download Play will automatically go back to normal once you reboot your device.
 
-1. Launch the Download Play application (![]({{ "/images/download-play-icon.png" | absolute_url }}){: height="24px" width="24px"})
-1. Wait until you see the `Nintendo 3DS` and `Nintendo DS` buttons
-1. Press (Left Shoulder) + (D-Pad Down) + (Select) at the same time to open the Rosalina menu
-1. Select "Miscellaneous options"
-1. Select "Switch the hb. title to the current app."
-1. Press (B) to continue
-1. Press (B) to return to the Rosalina main menu
-1. Press (B) to exit the Rosalina menu
-1. Press (Home), then close Download Play
-1. Launch the Download Play application
-1. Your device should load the Homebrew Launcher
-  + If your device is stuck on the loading splash screen, you are missing `boot.3dsx` from the root of your SD card
+{% include_relative include/launch-hbl-dlp.txt %}
 
 #### Section IV - RTC and DSP Setup
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -37,7 +37,7 @@ Some of the instructions below are only applicable to the latest version of GodM
 
 ## Creating a NAND Backup
 
-{% include_relative include/nand-backup.txt %}
+{% include_relative include/nand-backup.txt is-powered-off="true" %}
 
 ## Restoring a NAND Backup
 
@@ -93,16 +93,7 @@ This will only work if the Health & Safety injection was performed by GodMode9 (
 **Note that this will erase the contents of your SD card!**
 {: .notice--danger}
 
-1. Launch GodMode9 by holding (Start) during boot
-1. Press (Home) to bring up the action menu
-1. Select "More..."
-1. Select "SD format menu"
-1. Select any EmuNAND options you wish to use
-  + Most users will want to select "No EmuNAND"
-1. Select "Auto"
-1. Press (A) to accept the label `GM9SD`
-  + Optionally, you may input a custom name for the SD card
-1. When prompted, input the key combo given to confirm
+{% include_relative include/format-sd-gm9.txt is-powered-off="true" %}
 
 ## Removing an NNID without formatting your device
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -37,26 +37,7 @@ Some of the instructions below are only applicable to the latest version of GodM
 
 ## Creating a NAND Backup
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Press (Home) to bring up the action menu
-1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Backup Options"
-1. Select "SysNAND Backup"
-1. Press (A) to confirm
-  + This process will take some time
-  + If you get an error, look for your issue in the [troubleshooting guide](troubleshooting#finalizing-setup)
-1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
-1. Hold (R) and press (Start) at the same time to power off your device
-1. Insert your SD card into your computer
-1. Copy `<date>_<serialnumber>_sysnand_##.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
-  + Make backups in multiple locations (such as online file storage)
-  + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
-1. Delete `<date>_<serialnumber>_sysnand_##.bin` and `<date>_<serialnumber>_sysnand_##.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
-1. Reinsert your SD card into your device
+{% include_relative include/nand-backup.txt %}
 
 ## Restoring a NAND Backup
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -37,7 +37,8 @@ Some of the instructions below are only applicable to the latest version of GodM
 
 ## Creating a NAND Backup
 
-{% include_relative include/nand-backup.txt is-powered-off="true" %}
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+{%- include_relative include/nand-backup.txt %}
 
 ## Restoring a NAND Backup
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -38,7 +38,7 @@ Some of the instructions below are only applicable to the latest version of GodM
 ## Creating a NAND Backup
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- include_relative include/nand-backup.txt %}
+{% include_relative include/nand-backup.txt %}
 
 ## Restoring a NAND Backup
 
@@ -95,7 +95,7 @@ This will only work if the Health & Safety injection was performed by GodMode9 (
 {: .notice--danger}
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- include_relative include/format-sd-gm9.txt %}
+{% include_relative include/format-sd-gm9.txt %}
 
 ## Removing an NNID without formatting your device
 

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -94,7 +94,8 @@ This will only work if the Health & Safety injection was performed by GodMode9 (
 **Note that this will erase the contents of your SD card!**
 {: .notice--danger}
 
-{% include_relative include/format-sd-gm9.txt is-powered-off="true" %}
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+{%- include_relative include/format-sd-gm9.txt %}
 
 ## Removing an NNID without formatting your device
 

--- a/_pages/en_US/include/ctrtransfer-cleanup.txt
+++ b/_pages/en_US/include/ctrtransfer-cleanup.txt
@@ -1,0 +1,5 @@
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Navigate to `[0:] SDCARD` -> `gm9`
+1. Press (X) on the CTRTransfer image `.bin` to delete it
+1. Press (A) to confirm
+1. Press (Start) to reboot your device

--- a/_pages/en_US/include/ctrtransfer-main.txt
+++ b/_pages/en_US/include/ctrtransfer-main.txt
@@ -1,0 +1,29 @@
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
+1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
+  + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
+1. Navigate to `[0:] SDCARD` -> `gm9`
+1. Press (A) on the CTRTransfer `.bin` to select it
+1. Select "CTRNAND options..."
+1. Select "Transfer image to CTRNAND"
+1. If prompted, select "Transfer to SysNAND"
+  + This prompt will only appear if you have an EmuNAND
+1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
+  + This process will take some time
+1. Once the transfer is completed, press (A) to continue
+1. Press (B) to decline relocking write permissions if prompted
+1. Press (B) twice to return to the main menu
+1. Press (Home) to bring up the action menu
+1. Select "Scripts..."
+1. Select "GM9Megascript"
+1. Select "Scripts from Plailect's Guide"
+1. Select "CTRTransfer Ticket Copy"
+1. When prompted, press (A) to proceed
+1. Press (A) to continue
+1. Press (B) to return to the main menu
+1. Select "Exit"
+1. Press (A) to relock write permissions if prompted
+1. Press (Start) to reboot your device
+1. Update your device by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
+  + Updates while using B9S + Luma (what you have) are safe
+  + If this gives you an error, set your DNS settings to "auto"

--- a/_pages/en_US/include/ctrtransfer-prep.txt
+++ b/_pages/en_US/include/ctrtransfer-prep.txt
@@ -1,0 +1,8 @@
+1. Power off your device
+1. Insert your SD card into your computer
+1. Create a folder named `3ds` on the root of your SD card if it does not already exist
+1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
+1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card
+1. Copy the 11.15.0 CTRTransfer image `.bin` from the CTRTransfer `.zip` to the `/gm9/` folder on your SD card
+1. Copy `FBI.3dsx` to the `/3ds/` folder on your SD card
+1. Reinsert your SD card into your device

--- a/_pages/en_US/include/ctrtransfer-ticket-copy.txt
+++ b/_pages/en_US/include/ctrtransfer-ticket-copy.txt
@@ -1,0 +1,16 @@
+If the script found no user tickets and told you to skip this section, you can skip this section.
+{: .notice--info}
+
+1. Launch FBI from the list of homebrew
+1. Select "SD"
+1. Select "gm9"
+1. Select "out"
+1. Select "ctrtransfer_tickets"
+1. Do the following process for either the `eshop` folder, `unknown` folder, or both
+  + Navigate to the folder
+  + Select "\<current directory>"
+  + Select "Install and delete all tickets"
+  + Wait. The system may appear to freeze, just give it time.
+  + Press (A) to confirm
+  + Press (B) to decline installing tickets from CDN.
+1. Press (Home) to exit FBI

--- a/_pages/en_US/include/format-sd-gm9.txt
+++ b/_pages/en_US/include/format-sd-gm9.txt
@@ -1,0 +1,16 @@
+{%- if include.is-powered-off == "true" %}
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+{%- endif %}
+1. Press (Home) to bring up the action menu
+1. Select "More..."
+1. Select "SD format menu"
+{%- if include.no-emunand == "true" %}
+1. Select "No EmuNAND"
+{%- else %}
+1. Select any EmuNAND options you wish to use
+  + Most users will want to select "No EmuNAND"
+{%- endif %}
+1. Select "Auto"
+1. Press (A) to accept the label `GM9SD`
+  + Optionally, you may input a custom name for the SD card
+1. When prompted, input the key combo given to confirm

--- a/_pages/en_US/include/format-sd-gm9.txt
+++ b/_pages/en_US/include/format-sd-gm9.txt
@@ -1,15 +1,7 @@
-{%- if include.is-powered-off == "true" %}
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- endif %}
 1. Press (Home) to bring up the action menu
 1. Select "More..."
 1. Select "SD format menu"
-{%- if include.no-emunand == "true" %}
 1. Select "No EmuNAND"
-{%- else %}
-1. Select any EmuNAND options you wish to use
-  + Most users will want to select "No EmuNAND"
-{%- endif %}
 1. Select "Auto"
 1. Press (A) to accept the label `GM9SD`
   + Optionally, you may input a custom name for the SD card

--- a/_pages/en_US/include/launch-hbl-dlp.txt
+++ b/_pages/en_US/include/launch-hbl-dlp.txt
@@ -1,0 +1,12 @@
+1. Launch the Download Play application (![]({{ "/images/download-play-icon.png" | absolute_url }}){: height="24px" width="24px"})
+1. Wait until you see the `Nintendo 3DS` and `Nintendo DS` buttons
+1. Press (Left Shoulder) + (D-Pad Down) + (Select) at the same time to open the Rosalina menu
+1. Select "Miscellaneous options"
+1. Select "Switch the hb. title to the current app."
+1. Press (B) to continue
+1. Press (B) to return to the Rosalina main menu
+1. Press (B) to exit the Rosalina menu
+1. Press (Home), then close Download Play
+1. Launch the Download Play application
+1. Your device should load the Homebrew Launcher
+  + If your device is stuck on the loading splash screen, you are missing `boot.3dsx` from the root of your SD card

--- a/_pages/en_US/include/nand-backup.txt
+++ b/_pages/en_US/include/nand-backup.txt
@@ -1,4 +1,6 @@
+{%- if include.is-powered-off == "true" %}
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+{%- endif %}
 1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"
@@ -11,7 +13,11 @@
 1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted
+{%- if include.no-power-off == "true" %}
+1. Hold (R) and press (B) at the same time to eject your SD card
+{%- else %}
 1. Hold (R) and press (Start) at the same time to power off your device
+{%- endif %}
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_##.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)

--- a/_pages/en_US/include/nand-backup.txt
+++ b/_pages/en_US/include/nand-backup.txt
@@ -10,11 +10,7 @@
 1. Press (B) to return to the main menu
 1. Select "Exit"
 1. Press (A) to relock write permissions if prompted
-{%- if include.no-power-off == "true" %}
-1. Hold (R) and press (B) at the same time to eject your SD card
-{%- else %}
 1. Hold (R) and press (Start) at the same time to power off your device
-{%- endif %}
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_##.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
   + Make backups in multiple locations (such as online file storage)

--- a/_pages/en_US/include/nand-backup.txt
+++ b/_pages/en_US/include/nand-backup.txt
@@ -1,0 +1,20 @@
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+1. Press (Home) to bring up the action menu
+1. Select "Scripts..."
+1. Select "GM9Megascript"
+1. Select "Backup Options"
+1. Select "SysNAND Backup"
+1. Press (A) to confirm
+  + This process will take some time
+  + If you get an error, look for your issue in the [troubleshooting guide](troubleshooting#finalizing-setup)
+1. Press (A) to continue
+1. Press (B) to return to the main menu
+1. Select "Exit"
+1. Press (A) to relock write permissions if prompted
+1. Hold (R) and press (Start) at the same time to power off your device
+1. Insert your SD card into your computer
+1. Copy `<date>_<serialnumber>_sysnand_##.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
+  + Make backups in multiple locations (such as online file storage)
+  + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
+1. Delete `<date>_<serialnumber>_sysnand_##.bin` and `<date>_<serialnumber>_sysnand_##.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
+1. Reinsert your SD card into your device

--- a/_pages/en_US/include/nand-backup.txt
+++ b/_pages/en_US/include/nand-backup.txt
@@ -1,6 +1,3 @@
-{%- if include.is-powered-off == "true" %}
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- endif %}
 1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"

--- a/_pages/en_US/move-emunand.txt
+++ b/_pages/en_US/move-emunand.txt
@@ -129,13 +129,13 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 #### Section VII - Backup SysNAND
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- include_relative include/nand-backup.txt %}
+{% include_relative include/nand-backup.txt -%}
 1. **Backup every file on your SD card to a folder on your computer; all files will be deleted in the following steps**
 
 #### Section VIII - Format SD card
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- include_relative include/format-sd-gm9.txt %}
+{% include_relative include/format-sd-gm9.txt -%}
 1. Hold (R) and press (B) at the same time to eject your SD card
 1. Insert your SD card into your computer
 1. Copy all your files back to your SD card

--- a/_pages/en_US/move-emunand.txt
+++ b/_pages/en_US/move-emunand.txt
@@ -135,7 +135,7 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 #### Section VIII - Format SD card
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{% include_relative include/format-sd-gm9.txt no-emunand="true" -%}
+{%- include_relative include/format-sd-gm9.txt %}
 1. Hold (R) and press (B) at the same time to eject your SD card
 1. Insert your SD card into your computer
 1. Copy all your files back to your SD card

--- a/_pages/en_US/move-emunand.txt
+++ b/_pages/en_US/move-emunand.txt
@@ -129,38 +129,12 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 
 #### Section VII - Backup SysNAND
 
-1. Press (Home) to bring up the action menu
-1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Backup Options"
-1. Select "SysNAND Backup"
-1. Press (A) to confirm
-  + This process will take some time
-  + If you get an error, make sure that you have at least 1.3GB of free space on your SD card
-1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
-1. Hold (R) and press (B) at the same time to eject your SD card
-1. Insert your SD card into your computer
-1. Copy `<date>_<serialnumber>_sysnand_##.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
-  + Make backups in multiple locations (such as online file storage)
-  + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
-1. Delete `<date>_<serialnumber>_sysnand_##.bin` and `<date>_<serialnumber>_sysnand_##.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
+{% include_relative include/nand-backup.txt no-power-off="true" -%}
 1. **Backup every file on your SD card to a folder on your computer; all files will be deleted in the following steps**
 
 #### Section VIII - Format SD card
 
-1. Reinsert your SD card into your device
-1. Press (Home) to bring up the action menu
-1. Select "More..."
-1. Select "SD format menu"
-1. Press (A) to confirm
-1. Select "No EmuNAND"
-1. Select "Auto"
-1. Press (A) to accept the label `GM9SD`
-  + Optionally, you may input a custom name for the SD card
-1. When prompted, input the key combo given to confirm
+{% include_relative include/format-sd-gm9.txt no-emunand="true" -%}
 1. Hold (R) and press (B) at the same time to eject your SD card
 1. Insert your SD card into your computer
 1. Copy all your files back to your SD card

--- a/_pages/en_US/move-emunand.txt
+++ b/_pages/en_US/move-emunand.txt
@@ -34,7 +34,7 @@ You MUST have already installed Luma3DS and boot9strap to use this.
 If you do not have any DSiWare games or saves that you care about, skip this section.
 {: .notice--info}
 
-1. Launch GodMode9 by holding (Start) during boot
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
 1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
   + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
@@ -71,7 +71,7 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 
 #### Section IV - Copy EmuNAND to SysNAND
 
-1. Launch GodMode9 by holding (Start) during boot
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 1. Navigate to `[E:] EMUNAND VIRTUAL`
 1. Press (A) on `nand.bin` to select it, then select "NAND image options...", then select "Restore SysNAND (safe)"
 1. Press (A) to unlock SysNAND overwriting, then input the key combo given
@@ -125,15 +125,16 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
   + Press (Start) to reboot your device
   + Launch the GBA VC game
   + Exit the GBA VC game
-1. Launch GodMode9 by holding (Start) during boot
 
 #### Section VII - Backup SysNAND
 
-{% include_relative include/nand-backup.txt no-power-off="true" -%}
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+{%- include_relative include/nand-backup.txt %}
 1. **Backup every file on your SD card to a folder on your computer; all files will be deleted in the following steps**
 
 #### Section VIII - Format SD card
 
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
 {% include_relative include/format-sd-gm9.txt no-emunand="true" -%}
 1. Hold (R) and press (B) at the same time to eject your SD card
 1. Insert your SD card into your computer

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -53,14 +53,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 
 #### Section I - Prep Work
 
-1. Power off your device
-1. Insert your SD card into your computer
-1. Create a folder named `3ds` on the root of your SD card if it does not already exist
-1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
-1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card
-1. Copy the 11.15.0 CTRTransfer image `.bin` from the CTRTransfer `.zip` to the `/gm9/` folder on your SD card
-1. Copy `FBI.3dsx` to the `/3ds/` folder on your SD card
-1. Reinsert your SD card into your device
+{% include_relative include/ctrtransfer-prep.txt %}
 
 #### Section II - NAND Backup
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
@@ -90,59 +83,15 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
   
 #### Section III - CTRTransfer
 
-1. Navigate to `[0:] SDCARD` -> `gm9`
-1. Press (A) on the CTRTransfer `.bin` to select it
-1. Select "CTRNAND options..."
-1. Select "Transfer image to CTRNAND"
-1. If prompted, select "Transfer to SysNAND"
-  + This prompt will only appear if you have an EmuNAND
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-  + This process will take some time
-1. Once the transfer is completed, press (A) to continue
-1. Press (B) to decline relocking write permissions if prompted
-1. Press (B) twice to return to the main menu
-1. Press (Home) to bring up the action menu
-1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Scripts from Plailect's Guide"
-1. Select "CTRTransfer Ticket Copy"
-1. When prompted, press (A) to proceed
-1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
-1. Press (Start) to reboot your device
-1. Update your device by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
-  + Updates while using B9S + Luma (what you have) are safe
-  + If this gives you an error, set your DNS settings to "auto"
+{% include_relative include/ctrtransfer-main.txt %}
 
 #### Section IV - Launching FBI
 
-1. Launch the Download Play application (this [icon]({{ "/images/download-play-icon.png" | absolute_url }}))
-1. Press (L) + (Down) + (Select) at the same time to open the Rosalina menu
-1. Select "Miscellaneous options"
-1. Select "Switch the hb. title to the current app."
-1. Press (B) to continue
-1. Press (B) to return to the Rosalina main menu
-1. Press (B) to exit the Rosalina menu
-1. Press (Home), then close Download Play
-1. Launch the Download Play application
-1. Your device should load the Homebrew Launcher
+{% include_relative include/launch-hbl-dlp.txt %}
 
 #### Section V - Reinstalling Tickets
 
-If the script found no user tickets and told you to skip this section, you can skip this section.
-{: .notice--info}
-
-1. Launch FBI from the list of homebrew
-1. Navigate to `SD` -> `gm9` -> `out` -> `ctrtransfer_tickets`
-1. Do the following process for either the `eshop` folder, `unknown` folder, or both
-  + Navigate to the folder
-  + Select "\<current directory>"
-  + Select "Install and delete all tickets"
-  + Wait. The system may appear to freeze, just give it time.
-  + Press (A) to confirm
-1. Press (Home) to exit FBI
+{% include_relative include/ctrtransfer-ticket-copy.txt %}
 
 #### Section VI - Region settings
 
@@ -153,10 +102,6 @@ If the script found no user tickets and told you to skip this section, you can s
 
 #### Section VII - Remove CTRTransfer image
 
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. Navigate to `[0:] SDCARD` -> `gm9`
-1. Press (X) on the CTRTransfer image `.bin` to delete it
-1. Press (A) to confirm
-1. Press (Start) to reboot your device
+{% include_relative include/ctrtransfer-cleanup.txt %}
 
 ___

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -57,7 +57,8 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 
 #### Section II - NAND Backup
 
-{% include_relative include/nand-backup.txt is-powered-off="true" %}
+1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
+{%- include_relative include/nand-backup.txt %}
 
 #### Section III - CTRTransfer
 

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -58,7 +58,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 #### Section II - NAND Backup
 
 1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-{%- include_relative include/nand-backup.txt %}
+{% include_relative include/nand-backup.txt %}
 
 #### Section III - CTRTransfer
 

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -56,31 +56,9 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 {% include_relative include/ctrtransfer-prep.txt %}
 
 #### Section II - NAND Backup
-1. Press and hold (Start), and while holding (Start), power on your device. This will launch GodMode9
-1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
-1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
-  + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
-1. Press (Home) to bring up the action menu
-1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Backup Options"
-1. Select "SysNAND Backup"
-1. Press (A) to confirm
-  + This process will take some time
-  + If you get an error, make sure that you have at least 1.3GB of free space on your SD card
-1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
-1. Hold (R) and press (B) at the same time to eject your SD card
-1. Insert your SD card into your computer
-1. Copy `<date>_<serialnumber>_sysnand_##.bin` and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
-  + Make backups in multiple locations (such as online file storage)
-  + These backups will save you from a brick and/or help you recover files from the NAND image if anything goes wrong in the future
-1. Delete `<date>_<serialnumber>_sysnand_##.bin` and `<date>_<serialnumber>_sysnand_##.bin.sha` from the `/gm9/out/` folder on your SD card after copying it
-1. Reinsert your SD card into your device
-  + If your SD card was not detected, hold (R) and press (B) at the same time to remount it
-  
+
+{% include_relative include/nand-backup.txt %}
+
 #### Section III - CTRTransfer
 
 {% include_relative include/ctrtransfer-main.txt %}

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -57,7 +57,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 
 #### Section II - NAND Backup
 
-{% include_relative include/nand-backup.txt %}
+{% include_relative include/nand-backup.txt is-powered-off="true" %}
 
 #### Section III - CTRTransfer
 


### PR DESCRIPTION
Pages using the CTRTransfer sections:
- ctrtransfer
- region-changing

Pages using the NAND backup section:
- godmode9-usage
- region-changing

Pages using GM9 SD format section:
- godmode9-usage
- move-emunand

Pages using the HBL launch via DLP section:
- finalizing-setup
- installing-boot9strap-(hbl-usm)