### PR TITLE
Move version selector to its own include

### DIFF
--- a/_includes/consoleVersionSelect.html
+++ b/_includes/consoleVersionSelect.html
@@ -1,0 +1,108 @@
+<div id="selectversion" class="selectversion" style="display:none">
+    <br>
+    <select id="major">
+      <option>0</option>
+      <option>1</option>
+      <option>2</option>
+      <option>3</option>
+      <option>4</option>
+      <option>5</option>
+      <option>6</option>
+      <option>7</option>
+      <option>8</option>
+      <option>9</option>
+      <option>10</option>
+      <option>11</option>
+    </select>.<select id="minor">
+        <option>0</option>
+        <option>1</option>
+        <option>2</option>
+        <option>3</option>
+        <option>4</option>
+        <option>5</option>
+        <option>6</option>
+        <option>7</option>
+        <option>8</option>
+        <option>9</option>
+        <option>10</option>
+        <option>11</option>
+        <option>12</option>
+        <option>13</option>
+        <option>14</option>
+        <option>15</option>
+        <option>16</option>
+    </select>.<select id="whydidnintendodecidetodothingslikethis">
+      <option>0</option>
+    </select>-<select id="nver">
+        <option>0</option>
+        <option>1</option>
+        <option>2</option>
+        <option>3</option>
+        <option>4</option>
+        <option>5</option>
+        <option>6</option>
+        <option>7</option>
+        <option>8</option>
+        <option>9</option>
+        <option>10</option>
+        <option>11</option>
+        <option>12</option>
+        <option>13</option>
+        <option>14</option>
+        <option>15</option>
+        <option>16</option>
+        <option>17</option>
+        <option>18</option>
+        <option>19</option>
+        <option>20</option>
+        <option>21</option>
+        <option>22</option>
+        <option>23</option>
+        <option>24</option>
+        <option>25</option>
+        <option>26</option>
+        <option>27</option>
+        <option>28</option>
+        <option>29</option>
+        <option>30</option>
+        <option>31</option>
+        <option>32</option>
+        <option>33</option>
+        <option>34</option>
+        <option>35</option>
+        <option>36</option>
+        <option>37</option>
+        <option>38</option>
+        <option>39</option>
+        <option>40</option>
+        <option>41</option>
+        <option>42</option>
+        <option>43</option>
+        <option>44</option>
+        <option>45</option>
+        <option>46</option>
+        <option>47</option>
+        <option>48</option>
+        <option>49</option>
+    </select><select id="region">
+      <option>E</option>
+      <option>U</option>
+      <option>J</option>
+      <option>K</option>
+      <option>T</option>
+      <option>C</option>
+    </select>
+    <br>
+    <input type="button" onclick="redirect()" value="Confirm">
+</div>
+
+<script>
+document.getElementById("selectversion").style.display = "block";
+</script>
+
+<p id="result_invalidVersion" style="display:none">{{ include.invalidVersion }}</p>
+<p id="result_methodUnavailable" style="display:none">{{ include.methodUnavailable }}</p>
+
+<script src="/assets/js/selecting.js"></script>
+
+<noscript>Please enable JavaScript to continue with the guide.</noscript>

--- a/_pages/en_US/get-started.txt
+++ b/_pages/en_US/get-started.txt
@@ -24,103 +24,6 @@ If you see an unusual menu, STOP - you already have custom firmware! Continue fr
 #### Section III - Select a Method
 
 To find the correct method for your device, please enter the system version you found in Section II.
-<div class="selectversion">
-<br>
-<select id="major">
-  <option>0</option>
-  <option>1</option>
-  <option>2</option>
-  <option>3</option>
-  <option>4</option>
-  <option>5</option>
-  <option>6</option>
-  <option>7</option>
-  <option>8</option>
-  <option>9</option>
-  <option>10</option>
-  <option>11</option>
-</select>.<select id="minor">
-    <option>0</option>
-    <option>1</option>
-    <option>2</option>
-    <option>3</option>
-    <option>4</option>
-    <option>5</option>
-    <option>6</option>
-    <option>7</option>
-    <option>8</option>
-    <option>9</option>
-    <option>10</option>
-    <option>11</option>
-    <option>12</option>
-    <option>13</option>
-    <option>14</option>
-    <option>15</option>
-    <option>16</option>
-</select>.<select id="whydidnintendodecidetodothingslikethis">
-  <option>0</option>
-</select>-<select id="nver">
-    <option>0</option>
-    <option>1</option>
-    <option>2</option>
-    <option>3</option>
-    <option>4</option>
-    <option>5</option>
-    <option>6</option>
-    <option>7</option>
-    <option>8</option>
-    <option>9</option>
-    <option>10</option>
-    <option>11</option>
-    <option>12</option>
-    <option>13</option>
-    <option>14</option>
-    <option>15</option>
-    <option>16</option>
-    <option>17</option>
-    <option>18</option>
-    <option>19</option>
-    <option>20</option>
-    <option>21</option>
-    <option>22</option>
-    <option>23</option>
-    <option>24</option>
-    <option>25</option>
-    <option>26</option>
-    <option>27</option>
-    <option>28</option>
-    <option>29</option>
-    <option>30</option>
-    <option>31</option>
-    <option>32</option>
-    <option>33</option>
-    <option>34</option>
-    <option>35</option>
-    <option>36</option>
-    <option>37</option>
-    <option>38</option>
-    <option>39</option>
-    <option>40</option>
-    <option>41</option>
-    <option>42</option>
-    <option>43</option>
-    <option>44</option>
-    <option>45</option>
-    <option>46</option>
-    <option>47</option>
-    <option>48</option>
-    <option>49</option>
-</select><select id="region">
-  <option>E</option>
-  <option>U</option>
-  <option>J</option>
-  <option>K</option>
-  <option>T</option>
-  <option>C</option>
-</select>
-<br>
-<input type="button" onclick="redirect()" value="Confirm">
-</div>
 
 {% capture invalidVersion %}
 This doesn't seem to be a valid system version.
@@ -130,9 +33,7 @@ This doesn't seem to be a valid system version.
 You currently cannot hack your 3DS on this version using the main methods. If you want to hack your console, you have to use ntrboot.
 {% endcapture %}
 
-<p id="result_invalidVersion" style="display:none">{{ invalidVersion }}</p>
-<p id="result_methodUnavailable" style="display:none">{{ methodUnavailable }}</p>
-<noscript>Please enable JavaScript to continue with the guide.</noscript>
+{% include consoleVersionSelect.html invalidVersion=invalidVersion methodUnavailable=methodUnavailable %}
 
 ---
 #### Alternate Methods
@@ -144,5 +45,3 @@ Otherwise, methods that work on all versions are available, but require addition
 1. [kartdlphax](installing-boot9strap-(kartdlphax)) - requires a second hacked 3DS and a copy of Mario Kart 7
 1. [ntrboot](ntrboot) - requires compatible DS flashcart
 1. [Installing boot9strap (Hardmod)](installing-boot9strap-(hardmod)) - requires soldering
-
-<script src="/assets/js/selecting.js"></script>


### PR DESCRIPTION
This time, it's an HTML include, and not a relative include

This way changing the HTML tags like what happened the last time we edited this doesn't break all translations for the 400th time

Fixes #2225 