### PR TITLE
Add GitHub Actions build script to bump Jekyll to v4

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,47 @@
+name: Deploy site
+
+on:
+  push:
+    branches: [ master ]
+    paths:
+      - _pages/**
+      - .github/workflows/publish.yml
+      - package.json
+      - Gemfile
+  workflow_dispatch:
+
+jobs:
+  doc-deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: recursive
+
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+
+      - name: Install dependencies
+        run: bundle install
+
+      - name: Run Jekyll
+        # Build the site using Jekyll
+        run: bundle exec jekyll build
+
+        # Copy (or touch) other needed files
+        # .nojekyll: to tell GH Pages to not rebuild (lol)
+        # CNAME: to tell GH Pages about the domain name
+      - name: Post-Jekyll build copy files
+        run: |
+          cp CNAME _site
+          touch _site/.nojekyll
+
+      - name: Deploy 🚀
+        uses: JamesIves/github-pages-deploy-action@v4.4.1
+        with:
+          branch: gh-pages # The branch the action should deploy to.
+          folder: _site # The folder the action should deploy.
+          clean: true # Automatically remove deleted files from the deploy branch

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,11 +3,6 @@ name: Deploy site
 on:
   push:
     branches: [ master ]
-    paths:
-      - _pages/**
-      - .github/workflows/publish.yml
-      - package.json
-      - Gemfile
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
**Description**

This allows us to use Jekyll v4, by separately building the website and pushing it to `gh-pages` branch.

This requires GitHub Pages to point to `gh-pages` branch. 

This is currently untested, and is really only here if we ever need some feature in Jekyll v4 that GH Pages's v3 doesn't offer (or more accurately, when I eventually _snap._)