### PR TITLE
fix wrong redirection for unsupported kor ssloth-browser

### DIFF
--- a/assets/js/selecting.js
+++ b/assets/js/selecting.js
@@ -28,15 +28,16 @@ function sslothable(s, n) {
 }
 
 // CVer:NVer map for KOR region
+// KOR/CHN/TWN Old 3DS browser (spider) 1.7630 (v10240, shipped with 11.1~11.8) isn't supported by browserhax
 // CHN/TWN isn't validated for now as those cannot exploit atm
-function sslothablekor(s, n) {
+function sslothablekor(s, n, o) {
     if
         (
-        (s == 4 && n == 33) ||
-        (s == 5 && n == 34) ||
-        (s == 6 && n == 35) ||
-        (s == 7 && n == 35) ||
-        (s == 8 && n == 35) ||
+        (!o && s == 4 && n == 33) ||
+        (!o && s == 5 && n == 34) ||
+        (!o && s == 6 && n == 35) ||
+        (!o && s == 7 && n == 35) ||
+        (!o && s == 8 && n == 35) ||
         (s == 9 && n == 36) ||
         (s == 10 && n == 37) ||
         (s == 12 && n == 38) ||
@@ -119,7 +120,7 @@ function redirect() {
                 window.location.href = "installing-boot9strap-(soundhax)";
             }
             // check for versions that are not cartupdated, cartupdated consoles cannot access the browser, see troubleshooting for solution
-            else if (sslothablekor(minor.value, nver.value)) {
+            else if (sslothablekor(minor.value, nver.value, isO3DS)) {
                 window.location.href = "installing-boot9strap-(ssloth-browser)";
             }
             else if (minor.value < 15 && isO3DS) {


### PR DESCRIPTION
both surprised and not, very specific version of old 3ds kor(/twn/chn) browser, 1.7630/v10240, should be shipped with 11.1~11.8, isn't supported by browserhax. weird gap here, but [it simply exist](https://github.com/zoogie/web/blob/master/nbhax/index.html#L68-L73).
probably will never notice this without [existing case](https://discord.com/channels/196618637950451712/247557068490276864/1108600147878887475)
