### PR TITLE
Fix SafeB9SInstaller troubleshooting link

### DIFF
--- a/_pages/en_US/include/install-boot9strap-safeb9sinstaller.txt
+++ b/_pages/en_US/include/install-boot9strap-safeb9sinstaller.txt
@@ -3,7 +3,7 @@ In this section, you will install custom firmware onto your device.
 {%- endif %}
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
-  + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troublshooting#issues-with-safeb9sinstaller)
+  + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting#issues-with-safeb9sinstaller)
 {%- if include.isbootfirm == "true" %}
 1. Once it is completed, force your device to power off by holding down the power button
   + Your device will only boot to the SafeB9SInstaller screen until the next section is completed


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->
The troubleshooting link for Installing boot9strap (USM): Section IV has a typo and is broken