### PR TITLE
Fix broken KOR SSLoth-Browser again... actually fix more this time

### DIFF
--- a/assets/js/selecting.js
+++ b/assets/js/selecting.js
@@ -45,11 +45,11 @@ function can_ssloth(major, minor, native, region, model) {
         } else if (region == "K") {
             if
                 (
-                (!model && minor == 4 && native == 33) ||
-                (!model && minor == 5 && native == 34) ||
-                (!model && minor == 6 && native == 35) ||
-                (!model && minor == 7 && native == 35) ||
-                (!model && minor == 8 && native == 35) ||
+                (model && minor == 4 && native == 33) ||
+                (model && minor == 5 && native == 34) ||
+                (model && minor == 6 && native == 35) ||
+                (model && minor == 7 && native == 35) ||
+                (model && minor == 8 && native == 35) ||
                 (minor == 9 && native == 36) ||
                 (minor == 10 && native == 37) ||
                 (minor == 12 && native == 38) ||


### PR DESCRIPTION
Well, I'll say never mix integer with bool
This new version literally inverted new/old for kor
I originally wrote it as ``!old`` so new only, it's literally now ``!(new=1=true)`` so old only

Yeah, another [case](https://discord.com/channels/196618637950451712/196635695958196224/1111950239792898128) for me to notice this
