### PR TITLE
Fix wrong movable.sed requirement for smilehax-iie

### DIFF
--- a/_pages/en_US/homebrew-launcher-(smilehax-iie).txt
+++ b/_pages/en_US/homebrew-launcher-(smilehax-iie).txt
@@ -18,7 +18,6 @@ This set of instructions does not support the Japanese version of SmileBASIC.
 + The game "SmileBASIC" installed on your device
   + If you have downloaded it before, you can [redownload it](https://en-americas-support.nintendo.com/app/answers/detail/a_id/607/~/how-to-download-or-redownload-content-in-nintendo-3ds-eshop)
   + Your SD card must be inserted in your device to install SmileBASIC
-+ Your `movable.sed` file from completing [Seedminer](seedminer)
 + The latest release of [smilehax-IIe](https://github.com/zoogie/smilehax-IIe/releases/download/v1.0/Release_sh2e_v1.0.zip) (direct download) 
 + The latest release of [Luma3DS](https://github.com/LumaTeam/Luma3DS/releases/latest) (the Luma3DS `.zip` file)
 + [otherapps.zip]({{ base_path }}/assets/otherapps.zip) (direct download)


### PR DESCRIPTION
Yeah, why we need movable.sed to dump movable.sed