### PR TITLE
troubleshooting: remove redundant SSLoth-Browser cartupdate steps

### DIFF
--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -398,35 +398,6 @@ Follow these steps in order:
 <details>{{ compat | markdownify }}</details>
 
 {% capture compat %}
-<summary><u>"To use the Internet Browser, please update your system using the System Update option in the System Settings."</u></summary>
-
-First, make sure you entered the correct proxy for the connection you're using. If not, go back to [Section II](installing-boot9strap-(ssloth-browser).html#section-ii---ssloth). If the proxy is correct, then your console has been cart-updated, which means an alternate exploit will need to be used.
-
-<u>Method 1</u><br>
-If the two numbers before the region in the system version string is equal to or less than 36 (e.g. Ver. 11.14.0-**36**U), you can follow [Soundhax](installing-boot9strap-(soundhax)). When prompted to select a firmware to generate the sound file, use:
-
-* 1.x - 2.1 if the number is between 0 and 2
-* 2.1 - 2.2 if the number is between 3 and 4
-* 3.x - 4.x if the number is between 5 and 10
-* 5.x - 11.3 if the number is between 11 and 36
-
-<u>Method 2 (Old 3DS only)</u><br>
-If you have an Old 3DS / Old 3DS XL / 2DS, you can try a Safe Mode update, which will trigger an alternate exploit:
-
-1. Ensure that the proxy that you used for SSLoth is still actively applied to your internet connection
-1. With your console powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), and while holding these buttons together, power on your console
-  + Keep holding the buttons until the console boots into Safe Mode (a "system update" menu)
-1. Press "OK" to accept the update
-1. If everything worked correctly, the update will fail and the 3DS will boot into SafeB9SInstaller. If it did, then continue from [Section IV](installing-boot9strap-(ssloth-browser)#section-iv---installing-boot9strap).
-
----
-
-If these methods didn't work (or do not apply to you), update your console to the latest version and follow [Seedminer](seedminer).
-
-{% endcapture %}
-<details>{{ compat | markdownify }}</details>
-
-{% capture compat %}
 <summary><u>Failed to open SafeB9SInstaller.bin</u></summary>
 
 The file `SafeB9SInstaller.bin` is missing or misplaced. Download the latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip), extract it, and place `SafeB9SInstaller.bin` on the root of your SD card. Do not add the `.bin` extension if you do not already see it.


### PR DESCRIPTION
This is unnecessary as, if the user used the version selector, they shouldn't be on a cartupdate.
