### PR TITLE
Add some more info on kartdlphax

### DIFF
--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -27,7 +27,7 @@ In order to follow these instructions, you will need the following:
 
 - A second 3DS with custom firmware (the **source 3DS**) that is the same region as the 3DS you are trying to modify (the **target 3DS**)
   - The consoles must be USA, JPN, or EUR region consoles
-  - The source 3DS can be one [region changed](region-changing) to match the target 3DS
+  - The source 3DS can be [region changed](region-changing) to match the target 3DS if necessary
 - A physical or digital copy of Mario Kart 7 that is the same region as both consoles
 - An SD card for both consoles
 

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -27,6 +27,7 @@ In order to follow these instructions, you will need the following:
 
 - A second 3DS with custom firmware (the **source 3DS**) that is the same region as the 3DS you are trying to modify (the **target 3DS**)
   - The consoles must be USA, JPN, or EUR region consoles
+  - The source 3DS can be one [region changed](region-changing) to match the target 3DS
 - A physical or digital copy of Mario Kart 7 that is the same region as both consoles
 - An SD card for both consoles
 


### PR DESCRIPTION
**Description**

This pull request adds a piece of information that might be very helpful for some people trying to get CFW on updated consoles: the source 3DS can be region-changed to match the target 3DS. 

kartdlphax requires two consoles on the same region, but nowhere does the documentation state whether region changed consoles work as the source 3DS; after a desperation move by myself today to get two JPN old 3DS LL on 11.17.0 running CFW, i can confirm it works even if the source 3DS wasn't originally the same region, as I did it using a region-changed EUR old 3DS. 

This info might be very helpful for people in the same situation as me, that have consoles from different regions and don't want to buy a flashcart.