### PR TITLE
post-safemodecheck: clarify that just the camera app needs to work

### DIFF
--- a/_pages/en_US/bannerbomb3-(legacy).txt
+++ b/_pages/en_US/bannerbomb3-(legacy).txt
@@ -41,7 +41,8 @@ ___
 
 ### Next steps: Choose an exploit
 
-If the camera appeared in the previous section, Safe Mode is likely to be working on your console.
+If the camera application appeared in the previous section, Safe Mode is likely to be working on your console.
+  - If your console instead showed an error message, your camera application did appear, but crashed.
 
 If the camera appeared, continue to [Installing boot9strap (USM)](installing-boot9strap-(usm))
 {: .notice--primary}

--- a/_pages/en_US/bannerbomb3.txt
+++ b/_pages/en_US/bannerbomb3.txt
@@ -44,7 +44,8 @@ ___
 
 ### Next steps: Choose an exploit
 
-If the camera appeared in the previous section, Safe Mode is likely to be working on your console.
+If the camera application appeared in the previous section, Safe Mode is likely to be working on your console.
+  - If your console instead showed an error message, your camera application did appear, but crashed.
 
 If the camera appeared, continue to [Installing boot9strap (USM)](installing-boot9strap-(usm))
 {: .notice--primary}

--- a/_pages/en_US/include/hbl-common-exploits-movable.txt
+++ b/_pages/en_US/include/hbl-common-exploits-movable.txt
@@ -1,6 +1,7 @@
 ### Next step: Choose an exploit
 
-If the camera appeared in the previous section, Safe Mode is likely to be working on your console.
+If the camera application appeared in the previous section, Safe Mode is likely to be working on your console.
+  - If your console instead showed an error message, your camera application did appear, but crashed.
 
 If the camera appeared, continue to [Installing boot9strap (HBL-USM)](installing-boot9strap-(hbl-usm))
 {: .notice--primary}

--- a/_pages/en_US/include/hbl-common-exploits.txt
+++ b/_pages/en_US/include/hbl-common-exploits.txt
@@ -1,6 +1,7 @@
 ### Next step: Choose an exploit
 
-If the camera appeared in the previous section, Safe Mode is likely to be working on your console.
+If the camera application appeared in the previous section, Safe Mode is likely to be working on your console.
+  - If your console instead showed an error message, your camera application did appear, but crashed.
 
 If the camera appeared, continue to [Installing boot9strap (HBL-USM)](installing-boot9strap-(hbl-usm))
 {: .notice--primary}


### PR DESCRIPTION
- It is not uncommon for users to have a broken camera
- In this case, camera app will try to load and then crash, which implies that shoulder buttons do work
- Let's make life easier for these users
