### PR TITLE
Add question about digital game and save data loss to FAQ

### DIFF
--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -57,9 +57,11 @@ No. Consoles with custom firmware can still play online and run physical cartrid
 <details>{{ compat | markdownify }}</details>
 
 {% capture compat %}
-<summary><u>Can I keep my NNID?</u></summary>
+<summary><u>Can I keep my NNID, saves, digital games (etc.)?</u></summary>
 
 Your NNID (if you have one) will not be affected by this guide. Consoles with a region of KOR, CHN, or TWN do not have NNID functionality to begin with and are thus unaffected.
+
+Following this guide alone should not result in data loss (saves, digital games, etc), but SD card corruption is always a possibility. You should make a backup of your SD card contents if you have important data.
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 


### PR DESCRIPTION
Digital game and save data loss is a common fear, so I believe it should be added to the pre-installation FAQ. This commit adds back a sentence that used to be on the home page that I believe was first written by lilyuwuu in pull #1888, then removed by the same person in commit 93b4f3b.