### PR TITLE
get-started: switch from CSS-based error messages to alerts

### DIFF
--- a/docs/public/assets/js/selecting.js
+++ b/docs/public/assets/js/selecting.js
@@ -194,7 +194,7 @@ function redirect() {
     document.getElementById("result_noneSelected").style.display = "none";
     document.getElementById("result_invalidVersion").style.display = "none";
     if ((!isN3DS) && (!isO3DS)) {
-        document.getElementById("result_noneSelected").style.display = "block";
+        alert(document.getElementById("result_noneSelected").innerText);
         return;
     }
 
@@ -204,7 +204,7 @@ function redirect() {
     else if(isN3DS) model = DEVICE_N3DS;
 
     if (!validate_version(major, minor, nver, region, model)) {
-        document.getElementById("result_invalidVersion").style.display = "block";
+        alert(document.getElementById("result_invalidVersion").innerText);
         return;
     }
 
@@ -218,6 +218,6 @@ function redirect() {
     if (redirected) return true;
 
     // if it actually got to this point, there is no exploit available.
-    document.getElementById("result_methodUnavailable").style.display = "block";
+    alert(document.getElementById("result_methodUnavailable").innerText);
     return false;
 }


### PR DESCRIPTION
May make it more explicit that user entered something wrong. Confirmed working with translations. No idea if it works on all browsers.