### PR TITLE
Update installing-boot9strap-(soundhax).txt

### DIFF
--- a/_pages/en_US/installing-boot9strap-(soundhax).txt
+++ b/_pages/en_US/installing-boot9strap-(soundhax).txt
@@ -49,7 +49,7 @@ In this section, you will copy the files needed to trigger both Soundhax and uni
 ![]({{ "/images/screenshots/boot9strap-folder.png" | absolute_url }})
 {: .notice--info}
 
-#### Section II - Launching SafeB9SInstaller
+#### Section II - Soundhax
 
 In this section, you will launch Soundhax through the Nintendo 3DS Sound app, which will use universal-otherapp to launch the boot9strap (custom firmware) installer.
 


### PR DESCRIPTION
Exploit pages use the exploit name for the section that launches SafeB9SInstaller (from what I've seen, at least)
