### PR TITLE
fredtool*: split Flipnote steps and b9stool steps, move things around to align

### DIFF
--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -100,21 +100,30 @@ These instructions are for Taiwanese consoles ONLY (as indicated by a T at the e
 1. Navigate to `Data Management` -> `DSiWare`
 1. Under the “SD Card” section, select the “Haxxxxxxxxx!” title
 1. Select "Copy", then select "OK"
+
+#### Section V - Flipnote Exploit
+
+In this section, you will perform a series of very specific steps within Flipnote Studio that, when performed correctly, will launch b9sTool, the boot9strap (custom firmware) installer.
+
+If you would prefer a visual guide to this section, one is available [here](https://zoogie.github.io/web/flipnote_directions/).
+{: .notice--info}
+
 1. Exit System Settings
 1. Launch Download Play on your console (the orange icon with a 3DS on it)
 1. Select "Nintendo DS"
 1. If the exploit was successful, your 3DS will have loaded into the JPN version of Flipnote Studio
+{% include_relative include/exploit-flipnote.txt %}
 
-#### Section V - Flipnote Exploit
+#### Section VI - Installing boot9strap
 
-{% include_relative include/install-boot9strap-b9stool.txt method="dsdlp" %}
+{% include_relative include/install-boot9strap-b9stool.txt %}
 
-#### Section VI - Luma3DS Configuration
+#### Section VII - Luma3DS Configuration
 
 1. Press and hold (Select), and while holding (Select), power on your console
 {% include_relative include/configure-luma3ds.txt %}
 
-#### Section VII - Restoring DS Download Play
+#### Section VIII - Restoring DS Download Play
 
 1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card
 1. Copy the `484E4441.bin`  file from the `clean` folder of the downloaded DSiWare archive (output_(name).zip) to the `Nintendo DSiWare` folder

--- a/_pages/en_US/include/exploit-flipnote.txt
+++ b/_pages/en_US/include/exploit-flipnote.txt
@@ -1,0 +1,12 @@
+1. Complete the initial setup process for the launched game until you reach the main menu
+    + Select the left option whenever prompted during the setup process
+    + If you encounter an issue while doing this section, [check this troubleshooting guide](troubleshooting#installing-boot9strap-fredtool) for your issue
+1. Using the touch-screen, select the large left box, then select the box with an SD card icon
+1. Once the menu loads, select the face icon, then the bottom right icon to continue
+1. Press (X) or (UP) on the D-Pad depending on which is shown on the top screen
+1. Select the second button along the top with a film-reel icon
+1. Scroll right until reel "3/3" is selected
+1. Tap the third box with the letter "A" in it
+1. Scroll left until reel "1/3" is selected
+1. Tap the fourth box with the letter "A" in it
+1. If the exploit was successful, your console will have loaded b9sTool

--- a/_pages/en_US/include/install-boot9strap-b9stool.txt
+++ b/_pages/en_US/include/install-boot9strap-b9stool.txt
@@ -1,26 +1,7 @@
-If you would prefer a visual guide to this section, one is available [here](https://zoogie.github.io/web/flipnote_directions/).
-{: .notice--info}
+In this section, you will install custom firmware onto your console.
 
-In this section, you will perform a series of very specific steps within Flipnote Studio that, when performed correctly, will launch b9sTool, the boot9strap (custom firmware) installer.
-
-1. Complete the initial setup process for the launched game until you reach the main menu
-    + Select the left option whenever prompted during the setup process
-    + If you encounter an issue while doing this section, [check this troubleshooting guide](troubleshooting#installing-boot9strap-fredtool) for your issue
-1. Using the touch-screen, select the large left box, then select the box with an SD card icon
-1. Once the menu loads, select the face icon, then the bottom right icon to continue
-1. Press (X) or (UP) on the D-Pad depending on which is shown on the top screen
-1. Select the second button along the top with a film-reel icon
-1. Scroll right until reel "3/3" is selected
-1. Tap the third box with the letter "A" in it
-1. Scroll left until reel "1/3" is selected
-1. Tap the fourth box with the letter "A" in it
-1. If the exploit was successful, your console will have loaded b9sTool
 1. Using the D-Pad, move to "Install boot9strap"
-{%- if include.method == "dsinternet" %}
-    + If you miss this step, the system will exit to HOME Menu instead of installing boot9strap and you will need to open Nintendo DS Connections and start over from the beginning of this section
-{%- elsif include.method == "dsdlp" %}
-    + If you miss this step, the system will exit to HOME Menu instead of installing boot9strap and you will need to open DS Download Play and start over from the beginning of this section
-{%- endif %}
+    + If you miss this step, the system will exit to HOME Menu instead of installing boot9strap and you will need to start over from the previous section
 1. Press (A), then press START and SELECT at the same time to begin the process
 1. Once completed and the bottom screen says "done.", exit b9sTool, then power off your console
     + You may have to force power off by holding the power button

--- a/_pages/en_US/installing-boot9strap-(fredtool-inject).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool-inject).txt
@@ -73,23 +73,32 @@ In this section, you will copy the hacked DS Connection Settings DSiWare to inte
 1. Select the "Haxxxxxxxxx!" title
     + If you are unable to select the "Haxxxxxxxxx" title, [follow this troubleshooting guide](troubleshooting#installing-boot9strap-fredtool)
 1. Select "Copy", then select "OK"
+
+#### Section IV - Flipnote Exploit
+
+In this section, you will perform a series of very specific steps within Flipnote Studio that, when performed correctly, will launch b9sTool, the boot9strap (custom firmware) installer.
+
+If you would prefer a visual guide to this section, one is available [here](https://zoogie.github.io/web/flipnote_directions/).
+{: .notice--info}
+
 1. Return to main menu of the System Settings
 1. Navigate to `Internet Settings` -> `Nintendo DS Connections`, then select "OK" ([image](/images/screenshots/fredtool/dsconnection.png))
 1. If the exploit was successful, your console will have loaded the JPN version of Flipnote Studio
     + If your console does not load the JPN version of Flipnote Studio, [follow this troubleshooting guide](troubleshooting#installing-boot9strap-fredtool)
+{% include_relative include/exploit-flipnote.txt %}
 
-#### Section IV - Flipnote Exploit
+#### Section V - Installing boot9strap
 
-{% include_relative include/install-boot9strap-b9stool.txt method="dsinternet" %}
+{% include_relative include/install-boot9strap-b9stool.txt %}
 
-#### Section V - Luma3DS Configuration
+#### Section VI - Luma3DS Configuration
 
 1. Press and hold (Select), and while holding (Select), power on your console
 {% include_relative include/configure-luma3ds.txt %}
 
 {% include_relative include/luma3ds-installed-note.txt %}
 
-#### Section VI - Restoring DS Connection Settings
+#### Section VII - Restoring DS Connection Settings
 
 In this section, you will restore DS Connection Settings to the way it was before it was temporarily replaced with Flipnote Studio in an earlier section.
 


### PR DESCRIPTION
**Description**

This commit splits the rather large Flipnote exploit section into the following includes:
    - exploit-flipnote
    - install-boot9strap-b9stool

This also rewords portions of the Fredtool steps in individual pages so that the steps to launch Flipnote Studio are now in the Flipnote Exploit section, so as to make the b9stool section flow through easily.

This also allows to remove more arguments within the `include_relative` directive.
