### PR TITLE
actually, don't handle all cases ~~Add frankenfirm soundhax to troubleshooting~~

### DIFF
--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -276,13 +276,29 @@ If your console is not on those firmwares, it likely indicates that you already 
 <summary><u>"An error has occurred, forcing the software to close..." (white message box)</u></summary>
 
 There is an issue with your `otherapp.bin` file (it is missing, misplaced, or corrupted). Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) and place it on the root of your SD card.
+
+If the above doesn't fix your issue, and you are using an Old 3DS / Old 3DS XL / Old 2DS, you may be encountering a specific issue involving cartridge updates. Take another look at the system version. If the last number, e.g. 4 in 11.3.0-**4**U, is 4 and lower and the system version is between 5.0.0 and 11.3.0 inclusive, replace the soundhax file on the root of your SD card with the following one according to your region:
+
++ [USA](https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax-usa-o3ds-v2.1and2.2-post5franken.m4a)
++ [EUR](https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax-eur-o3ds-v2.1and2.2-post5franken.m4a)
++ [JPN](https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax-jpn-o3ds-v2.1and2.2-post5franken.m4a)
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 
 {% capture compat %}
 <summary><u>"Could not play"</u></summary>
 
-You have the wrong Soundhax file for your console and region, or your console is incompatible with Soundhax. In the latter case, your course of action will determine on what version your 3DS is currently on. Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+You have the wrong Soundhax file for your console, region and version. Double-check that you entered all the info correctly into the [Soundhax website](https://soundhax.com/), redownload your soundhax file, and replace it with the one on the root of your SD card. If your system version is exactly 2.1.0, make sure to try both ``1.X - 2.1`` and ``2.1 - 2.2`` file.
+
+If the above doesn't fix your issue, and you are using an Old 3DS / Old 3DS XL / Old 2DS, you may be encountering a specific issue involving cartridge updates. Take another look at the system version. If the last number, e.g. 0 in 11.3.0-**0**U, is 3 and lower and the system version is between 5.0.0 and 11.3.0 inclusive, replace the soundhax file on the root of your SD card with the following one according to your region:
+
++ [USA](https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax-usa-o3ds-pre2.1-post5franken.m4a)
++ [EUR](https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax-eur-o3ds-pre2.1-post5franken.m4a)
++ [JPN](https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax-jpn-o3ds-pre2.1-post5franken.m4a)
+
+If your region isn't on the list above or the version doesn't match, this troubleshooting option doesn't apply to you.
+
+If none of these fix your issue, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 


### PR DESCRIPTION
actually, don't handle all cases
~~first, ref: https://gist.github.com/danny8376/524394a41202c3617e6a1ef6c181fa91
i think i cover all the ifs correctly... hopefully

for 2.1.0, from my test, it'll always show unplayable if used wrong file for both cases
2.1.0-4 will surely be 2.1-2.2 one
2.1.0-3 or lower, it should be 1.x-2.1 one, unless there are some 2.1.0 cartridges that contains v1027 sound app, which i don't know if any exists
maybe this can also be a sub-bullet in soundhax page for file selection, not sure if really needed~~