### PR TITLE
Add frankenfirm soundhax to troubleshooting

### DIFF
--- a/docs/public/assets/js/link-common.js
+++ b/docs/public/assets/js/link-common.js
@@ -28,6 +28,11 @@ if (selectedVersion && window.MATCH && window.generateLink) {
     } else {
         replaceLink();
     }
+
+    if (!window.autoLinkAddedCustomEvent) {
+        window.autoLinkAddedCustomEvent = true;
+        document.addEventListener("customEventReplaceLink", replaceLink);
+    }
 }
 
 })();

--- a/docs/public/assets/js/soundhax-frankenfirm-link.js
+++ b/docs/public/assets/js/soundhax-frankenfirm-link.js
@@ -1,0 +1,145 @@
+/*
+    Copyright (C) 2024 DannyAAM
+
+    SPDX-License-Identifier: MIT
+*/
+
+(() => {
+
+const BASE = "https://github.com/danny8376/soundhax/raw/frankenfirmware/soundhax";
+
+window.MATCH = "soundhax.686178.xyz/frankenfirm";
+
+// adopt from https://github.com/danny8376/soundhax/blob/2a2c2499ad45d9216ae4c9d157dfb90dfd3b6bd4/docs/js/frankenfirm.js#L82-L237
+window.generateLink = (major, minor, nver, region, model, link) => {
+    console.log("MATCH")
+    const fileRegion = FILENAME_REGION_MAP[region];
+    const errorIndex = link.lastIndexOf("?");
+    if (errorIndex == -1) {
+        return null;
+    }
+    const error = link.slice(errorIndex + 1);
+    console.log(error);
+
+    if (model == DEVICE_N3DS || ["K", "C", "T"].includes(region)) {
+        return null;
+    }
+
+    switch (parseInt(nver)) {
+        case 0:
+        case 1:
+        case 2:
+        case 3:
+            console.log("nver 0-3")
+            if (major < 2 || (major == 2 && minor <= 1)) {
+                switch (error) {
+                    case "unplayable":
+                        // very unlikely to have v1027 sound app in this case?
+                        return `${BASE}-${fileRegion}-o3ds-pre2.1.m4a`;
+                    case "crash":
+                        return null; // WTF
+                    default:
+                        return null;
+                }
+            } else if (major < 5) {
+                switch (error) {
+                    case "unplayable":
+                        return `${BASE}-${fileRegion}-o3ds-pre2.1.m4a`;
+                    case "crash":
+                        return `${BASE}-${fileRegion}-o3ds-v2.1and2.2.m4a`;
+                    default:
+                        return null;
+                }
+            } else if (major < 11 || (major == 11 && minor <= 3)) {
+                switch (error) {
+                    case "unplayable":
+                        return `${BASE}-${fileRegion}-o3ds-pre2.1-post5franken.m4a`;
+                    case "crash":
+                        return `${BASE}-${fileRegion}-o3ds-v2.1and2.2-post5franken.m4a`;
+                    default:
+                        return null;
+                }
+            } else if ((major == 11 && minor > 3) || major > 11) {
+                    return null;
+            }
+        case 4:
+            console.log("nver 4")
+            if (major < 2 || (major == 2 && minor < 1)) {
+                return null; // WTF
+            } else if (major == 2 && minor == 1) {
+                switch (error) {
+                    case "unplayable":
+                        return `${BASE}-${fileRegion}-o3ds-v2.1and2.2.m4a`;
+                    case "crash":
+                        return null; // WTF
+                    default:
+                        return null;
+                }
+            } else if (major < 5) {
+                switch (error) {
+                    case "unplayable":
+                        return null;
+                    case "crash":
+                        return `${BASE}-${fileRegion}-o3ds-v2.1and2.2.m4a`;
+                    default:
+                        return null;
+                }
+            } else if (major < 11 || (major == 11 && minor <= 3)) {
+                switch (error) {
+                    case "unplayable":
+                        return null;
+                    case "crash":
+                        return `${BASE}-${fileRegion}-o3ds-v2.1and2.2-post5franken.m4a`;
+                    default:
+                        return null;
+                }
+            } else if ((major == 11 && minor > 3) || major > 11) {
+                    return null;
+            }
+        case 5:
+        case 6:
+        case 7:
+        case 8:
+        case 9:
+        case 10:
+            console.log("nver 5-10");
+            if (major < 5) {
+                switch (error) {
+                    case "unplayable":
+                    case "crash":
+                        return null;
+                    default:
+                        return null;
+                }
+            } else if (major < 11 || (major == 11 && minor <= 3)) {
+                switch (error) {
+                    case "unplayable":
+                    case "crash":
+                        return null;
+                    default:
+                        return null;
+                }
+            } else if ((major == 11 && minor > 3) || major > 11) {
+                    return null;
+            }
+        default:
+            if (nver < 37) {
+                console.log("nver 11-36");
+                switch (error) {
+                    case "unplayable":
+                    case "crash":
+                        return null;
+                    default:
+                        return `${BASE}-${fileRegion}-o3ds-post5.0.m4a`;
+                }
+            } else {
+                console.log("nver 37+");
+                return null;
+            }
+    }
+}
+
+// workaround for link-common.js won't get loaded again if jump from other also loaded page
+document.dispatchEvent(new Event("customEventReplaceLink"));
+
+})();

--- a/docs/troubleshooting-soundhax.md
+++ b/docs/troubleshooting-soundhax.md
@@ -1,3 +1,11 @@
+---
+head: [
+    ['script', {src: '/assets/js/common.js'}],
+    ['script', {src: '/assets/js/soundhax-frankenfirm-link.js'}],
+    ['script', {src: '/assets/js/link-common.js'}],
+]
+---
+
 # Troubleshooting (Soundhax)
 
 This page offers troubleshooting advice for commonly encountered issues with the "Installing boot9strap (Soundhax)" page, which is used on system versions between 1.0.0 and 11.3.0. If you are unable to solve your issue with the advice on this page, please join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and describe your issue, including what you have already tried.
@@ -16,11 +24,19 @@ If your console is not on those firmwares, it likely indicates that you already 
 
 There is an issue with your `otherapp.bin` file (it is missing, misplaced, or corrupted). Download the latest release of [universal-otherapp](https://github.com/TuxSH/universal-otherapp/releases/latest) and place it on the root of your SD card.
 
+If the above doesn't fix your issue, and you are using an Old 3DS / Old 3DS XL / Old 2DS, you may be encountering an issue involving cartridge updates. Take another look at the system version. If the last number is 4 or lower (e.g. 11.3.0-**4**U), replace the Soundhax file on the root of your SD card with the one from [here](http://soundhax.686178.xyz/frankenfirm.html?crash).
+
+If none of these fix your issue, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+
 :::
 
 ::: details "Could not play"
 
-You have the wrong Soundhax file for your console and region, or your console is incompatible with Soundhax. In the latter case, your course of action will determine on what version your 3DS is currently on. Join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
+You have the wrong Soundhax file for your console, region and version. Double-check that you entered all the info correctly into the [Soundhax website](https://soundhax.com/), redownload your Soundhax file, and replace it with the one on the root of your SD card.
+
+If the above doesn't fix your issue, and you are using an Old 3DS / Old 3DS XL / Old 2DS, you may be encountering an issue involving cartridge updates. Take another look at the system version. If the last number is 3 or lower (e.g. 11.3.0-**0**U), replace the Soundhax file on the root of your SD card with the one from [here](http://soundhax.686178.xyz/frankenfirm.html?unplayable).
+
+If none of these fix your issue, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) for assistance.
 
 :::
 


### PR DESCRIPTION
first, ref: https://gist.github.com/danny8376/524394a41202c3617e6a1ef6c181fa91

the site should cover all cases include 2.1.0 handling, hopefully
[js part of the site](https://github.com/nedwill/soundhax/compare/master...danny8376:soundhax:frankenfirmware#diff-4d6443d6dc5d62f22ddb20623fe3686e9df0b374acbfed8fe67e8feba447f911)

and this should resolve #2279
i don't think there's a good way to determine which sound app version they have without running normal soundhax first, even though it's almost guaranteed to fail (for 5.0.0 and greater)