### PR TITLE
Remove F00D43D5.bin line

### DIFF
--- a/_pages/en_US/installing-boot9strap-(fredtool-inject).txt
+++ b/_pages/en_US/installing-boot9strap-(fredtool-inject).txt
@@ -50,7 +50,6 @@ In this section, you will copy the files necessary to temporarily replace DS Con
 1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card
     + `<ID0>` is the 32-letter folder name that you copied in [Seedminer](seedminer)
     + `<ID1>` is a 32-letter folder inside of the `<ID0>`
-1. Delete `F00D43D5.bin` from your Nintendo DSiWare folder
 1. Copy the `42383841.bin`  file from the `hax` folder of the downloaded DSiWare archive (output_(name).zip) to the `Nintendo DSiWare` folder
     ![]({{ "/images/screenshots/bb3/dsiware-location-4.png" | absolute_url }}){: .notice--info}
 1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card


### PR DESCRIPTION
Looks to be a remnant from when we did BannerBomb3 -> Fredtool, but since we no longer do that, the F00D43D5.bin shouldn't be there.