### PR TITLE
Move the Luma3ds installed notice to after any post-install non-finalizing steps.

### DIFF
--- a/_pages/en_US/bannerbomb3-fredtool-(twn).txt
+++ b/_pages/en_US/bannerbomb3-fredtool-(twn).txt
@@ -136,6 +136,7 @@ If you would prefer a visual guide to this section, one is available [here](http
 1. Exit System Settings
 1. Power off your console
 
+{% include_relative include/luma3ds-installed-note.txt %}
 ___
 
 ### Continue to [Finalizing Setup](finalizing-setup)

--- a/_pages/en_US/installing-boot9strap-(kartdlphax).txt
+++ b/_pages/en_US/installing-boot9strap-(kartdlphax).txt
@@ -117,8 +117,6 @@ In this section, you will use Download Play to transfer the exploit data from th
 {% include_relative include/install-boot9strap-safeb9sinstaller.txt %}
 {%- include_relative include/configure-luma3ds.txt %}
 
-{% include_relative include/luma3ds-installed-note.txt %}
-
 #### Section VI - Removing menuhax67
 
 In this section, you will use the Homebrew Launcher to remove menuhax67, which will let you access the HOME Menu Settings option normally.
@@ -128,6 +126,7 @@ In this section, you will use the Homebrew Launcher to remove menuhax67, which w
 1. Select REMOVE menuhax67
 1. When you see "done.", press (A), then press (A) on "EXIT to menu"
 
+{% include_relative include/luma3ds-installed-note.txt %}
 ___
 
 ### Continue to [Finalizing Setup](finalizing-setup)

--- a/_pages/en_US/installing-boot9strap-(kartminer7).txt
+++ b/_pages/en_US/installing-boot9strap-(kartminer7).txt
@@ -101,8 +101,6 @@ In this section, you will have the 3DS generate some data in Mario Kart 7 that w
 {% include_relative include/install-boot9strap-safeb9sinstaller.txt %}
 {%- include_relative include/configure-luma3ds.txt %}
 
-{% include_relative include/luma3ds-installed-note.txt %}
-
 #### Section VII - Removing menuhax67
 
 In this section, you will use the Homebrew Launcher to remove menuhax67, which will let you access the HOME Menu Settings option normally.
@@ -115,6 +113,7 @@ In this section, you will use the Homebrew Launcher to remove menuhax67, which w
 At this point, you can re-enable wireless communications.
 {: .notice-info}
 
+{% include_relative include/luma3ds-installed-note.txt %}
 ___
 
 ### Continue to [Finalizing Setup](finalizing-setup)

--- a/_pages/en_US/installing-boot9strap-(menuhax).txt
+++ b/_pages/en_US/installing-boot9strap-(menuhax).txt
@@ -61,8 +61,6 @@ In this section you will use the menuhax67 exploit installed earlier to launch n
 {% include_relative include/install-boot9strap-safeb9sinstaller.txt %}
 {%- include_relative include/configure-luma3ds.txt %}
 
-{% include_relative include/luma3ds-installed-note.txt %}
-
 #### Section IV - Removing menuhax67
 
 In this section, you will trigger the BannerBomb3 exploit a second time so that you can uninstall the menuhax67 exploit you installed in Section II. This will allow you to use the HOME Menu settings normally again.
@@ -76,6 +74,7 @@ In this section, you will trigger the BannerBomb3 exploit a second time so that 
 1. Navigate to `Nintendo 3DS` -> `<ID0>` -> `<ID1>` -> `Nintendo DSiWare` on your SD card
 1. Delete `F00D43D5.bin` from your Nintendo DSiWare folder and from your computer. This file will not be needed anymore
 
+{% include_relative include/luma3ds-installed-note.txt %}
 ___
 
 ### Continue to [Finalizing Setup](finalizing-setup)

--- a/_pages/en_US/installing-boot9strap-(ssloth-browser).txt
+++ b/_pages/en_US/installing-boot9strap-(ssloth-browser).txt
@@ -71,12 +71,11 @@ In this section, you will visit the browser exploit webpage, which will use univ
 {% include_relative include/install-boot9strap-safeb9sinstaller.txt %}
 {%- include_relative include/configure-luma3ds.txt %}
 
-{% include_relative include/luma3ds-installed-note.txt %}
-
 #### Section V - Restoring default proxy
 
 {% include_relative include/rmproxy.txt %}
 
+{% include_relative include/luma3ds-installed-note.txt %}
 ___
 
 ### Continue to [Finalizing Setup](finalizing-setup)


### PR DESCRIPTION
This PR applies the change made in https://github.com/hacks-guide/Guide_3DS/commit/ddb273fedfb14da3ba5cb9cfb86ca6ca53863aca to the menuhax-based and SSLoth pages (to try to lessen the people skipping steps and for consistency with MSET9)

~~this also adds the notice to bb3 twn in the first place since it seemed to be missing, though I don't know how important this is in the first place~~