### PR TITLE
Update formatting-sd-(windows).txt

### DIFF
--- a/_pages/en_US/formatting-sd-(windows).txt
+++ b/_pages/en_US/formatting-sd-(windows).txt
@@ -62,6 +62,7 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 
 * guiformat shows the error "Failed to open device: GetLastError()=32"
     + Close everything that may be using the SD card, such as any File Explorer windows.
+    + If this issue persists, try reformatting the card to NTFS in File Explorer, close that window when it's done, and re-attempt the guiformat process.
 
 * guiformat shows the error "GetLastError()=1117"
     + Your SD card write-protection switch may be [enabled](/images/sdlock.png). The lock must be flipped upwards to allow writing to the SD card (including formatting).


### PR DESCRIPTION
This is what solved the issue for me

**Description**
I was encountering that error when trying to format, but I had all file explorer windows closed. I found [this](https://gbatemp.net/threads/unable-to-format-sd-card-with-guiformat.465080/) website, and tried both suggestions in it. Killing explorer.exe didn't help, but reformatting to NTFS did. 