### PR TITLE
11.16 and 11.17 Old 3DS both go to MSET9 anyways

### DIFF
--- a/_pages/en_US/installing-boot9strap-(super-skaterhax).txt
+++ b/_pages/en_US/installing-boot9strap-(super-skaterhax).txt
@@ -85,7 +85,7 @@ If you haven't already, make sure you have a working Internet connection set up 
     + If any prompts appear, approve all of them
     + If your console freezes on a yellow screen, hold the POWER button until it turns off, then retry this section
     + If your console freezes on a red screen, hold the POWER button until it turns off, redo step 3 of Section II, then retry this section
-    + If your console shows "Text" on the bottom screen, you have an Old 3DS and this exploit **will not work on your device** and you should do [MSET9](installing-boot9strap-(mset9)) instead
+    + If your console shows "Text" on the bottom screen, you have an Old 3DS and this exploit **will not work on your device**. If this is the case, you should follow [MSET9](installing-boot9strap-(mset9)) instead
     + If you get another error, try again up to 5 times, and if it still doesn't work, [follow this troubleshooting guide](troubleshooting#installing-boot9strap-super-skaterhax)
 1. Your console will have booted into the Homebrew Launcher
 1. Launch nimdsphax from the list of homebrew

--- a/_pages/en_US/installing-boot9strap-(super-skaterhax).txt
+++ b/_pages/en_US/installing-boot9strap-(super-skaterhax).txt
@@ -85,8 +85,7 @@ If you haven't already, make sure you have a working Internet connection set up 
     + If any prompts appear, approve all of them
     + If your console freezes on a yellow screen, hold the POWER button until it turns off, then retry this section
     + If your console freezes on a red screen, hold the POWER button until it turns off, redo step 3 of Section II, then retry this section
-    + If your console shows "Text" on the bottom screen, you have an Old 3DS and this exploit **will not work on your device**
-      + Return to [Get Started](get-started) and select Old 3DS/2DS as your model and reinput your system version
+    + If your console shows "Text" on the bottom screen, you have an Old 3DS and this exploit **will not work on your device** and you should do [MSET9](installing-boot9strap-(mset9)) instead
     + If you get another error, try again up to 5 times, and if it still doesn't work, [follow this troubleshooting guide](troubleshooting#installing-boot9strap-super-skaterhax)
 1. Your console will have booted into the Homebrew Launcher
 1. Launch nimdsphax from the list of homebrew


### PR DESCRIPTION
yeah this is my fault, but all versions that we direct skater to goes to mset9 on old 3ds, so its just easier for the user to have a direct link and not risk them messing up the input this time