### PR TITLE
mset error #19 -> mset-cli/mset-play-store

### DIFF
--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -583,7 +583,7 @@ The script has detected that the Nintendo 3DS folder is missing AND that you hav
 {% capture compat %}
 <summary><u>Error #18: MSET9 detected</u></summary>
 
-You didn't remove MSET9 when prompted to. Follow [Section IV - Removing MSET9](installing-boot9strap-(mset9)#section-iv---removing-mset9), then re-run the script.
+You didn't remove MSET9 when prompted to. Follow Section IV - Removing MSET9 from the [Windows/macOS/Linux guide](installing-boot9strap-(mset9-cli)#section-iv---removing-mset9) or the [Android/ChromeOS guide](installing-boot9strap-(mset9-play-store)#section-iv---removing-mset9), then re-run the script.
 
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>


### PR DESCRIPTION
This updates the troubleshooting for Error #18 of Finalizing Setup to send you to the removing MSET9 section for both the CLI method and the Play Store method, rather than just sending you to the landing page of MSET9.

The finalize script should be updated as well to include a new tinyurl link for both methods.