### PR TITLE
Remove reference to Nintendo 3DS for finalize.romfs placement.

### DIFF
--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -458,7 +458,7 @@ The file `finalize.romfs` is corrupt or unreadable. [Re-download it](/assets/fin
 {% capture compat %}
 <summary><u>Information #23: finalize.romfs in wrong location</u></summary>
 
-The file `finalize.romfs` was placed in the wrong location (the `Nintendo 3DS` folder instead of root of SD). The script will attempt to resolve this, but requires your permission to do so. Press (A) on the next few prompts to continue.
+The file `finalize.romfs` was placed in the wrong location instead of root of SD. The script will attempt to resolve this, but requires your permission to do so. Press (A) on the next few prompts to continue.
 
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>


### PR DESCRIPTION
While Nintendo 3DS is probably the folder they'll end up putting it in (many people confuse that with the root), there are other folders that the script can detect. They really don't need to know where they misplaced it, just that they did, and they should enter the keycombo to fix it.
