### PR TITLE
Changes to Section 2 Step 5 for MSET9

### DIFF
--- a/_pages/en_US/installing-boot9strap-(mset9-cli).txt
+++ b/_pages/en_US/installing-boot9strap-(mset9-cli).txt
@@ -77,7 +77,7 @@ These instructions must be followed **EXACTLY**, so double-check EVERYTHING you 
 1. Power off, then power on your console
 1. Press (A) to launch System Settings
 1. Navigate to `Data Management` -> `Nintendo 3DS` -> `Extra Data` ([image](/images/screenshots/mset9/settings-extdata.png))
-1. **Do not press any buttons or touch the screen** - ensure that you see the Mii Maker icon
+1. **Do not press any buttons or touch the screen**
 1. **With the console STILL ON, and without pressing any buttons or touching the screen**, remove your SD card from your console
     + The menu will refresh and say that no SD card is inserted, which is expected
 1. Insert your SD card into your computer

--- a/_pages/en_US/installing-boot9strap-(mset9-play-store).txt
+++ b/_pages/en_US/installing-boot9strap-(mset9-play-store).txt
@@ -70,7 +70,7 @@ These instructions must be followed **EXACTLY**, so double-check EVERYTHING you 
 1. Power off, then power on your console
 1. Press (A) to launch System Settings
 1. Navigate to `Data Management` -> `Nintendo 3DS` -> `Extra Data` ([image](/images/screenshots/mset9/settings-extdata.png))
-1. **Do not press any buttons or touch the screen** - ensure that you see the Mii Maker icon
+1. **Do not press any buttons or touch the screen**
 1. **With the console STILL ON, and without pressing any buttons or touching the screen**, remove your SD card from your console
     + The menu will refresh and say that no SD card is inserted, which is expected
 1. Insert your SD card into your phone/tablet/computer


### PR DESCRIPTION
To make things simpler and confuse users less, have users eject on page one without going hunting for mii maker, if mii maker is missing they will need to do Fresh anyway

This avoids people pressing buttons which can lead to a crash regardless