### PR TITLE
update guide for end of online play

### DIFF
--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -12,9 +12,6 @@ All future releases of Luma3DS will only be made in the `.firm` format, which wi
 
 To extract the `.7z` files linked on this page, you will need a file archiver like [7-Zip](http://www.7-zip.org/) or [The Unarchiver](https://theunarchiver.com/).
 
-While we believe that custom firmware is safe for online use, there have been online network bans in the past, primarily for cheating and suspicious eShop behavior.
-{: .notice--warning}
-
 ### What You Need
 
 To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this page, you will need a torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download).

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -52,7 +52,7 @@ Yes; Luma3DS will automatically ignore the region check for cartridges and insta
 {% capture compat %}
 <summary><u>Will I lose any features if I install CFW?</u></summary>
 
-No. Consoles with custom firmware can still play online and run physical cartridges as any other 3DS can.
+No. Consoles with custom firmware can download game updates and run physical cartridges as any other 3DS can.
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 
@@ -68,9 +68,7 @@ Following this guide alone should not result in data loss (saves, digital games,
 {% capture compat %}
 <summary><u>Will my 3DS be banned for having CFW?</u></summary>
 
-There was a ban wave in May 2017 that banned CFW users from online play (eShop access, NNIDs, and Nintendo Accounts were unaffected), seemingly at random. A ban wave at such a scale has not been seen since. That being said, we don't know what Nintendo may have in store in the future.
-
-At this time, we don't think that bans are something that you need to worry about.
+Bans are no longer possible because Nintendo Network services have been shut down (for everyone).
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 
@@ -93,7 +91,7 @@ You will need at least 1.5GB of free SD card space to follow this guide in its e
 
 No. While a DS flashcart can be used to mod a 3DS using [ntrboot](ntrboot), there is now a free software method available for most consoles.
 
-3DS-mode flashcarts like Gateway and Sky3DS are not recommended because they are obsolete and may carry ban or brick risk.
+3DS-mode flashcarts like Gateway and Sky3DS are not recommended because they are obsolete and may carry brick risk.
 {% endcapture %}
 <details>{{ compat | markdownify }}</details>
 

--- a/_pages/en_US/faq.txt
+++ b/_pages/en_US/faq.txt
@@ -4,7 +4,7 @@ title: "FAQ"
 {% include toc title="Table of Contents"%}
 
 {% capture update-notice %}
-{% include_relative include/3ds-11.17.txt %}
+{% include_relative include/3ds-online.txt %}
 {% endcapture %}
 <div class="notice--danger">{{ update-notice | markdownify }}</div>
 

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -116,18 +116,6 @@ You're done! Custom firmware is now fully configured on your console.
 Trying to figure out what to do with your newly modded device? Visit [our wiki](https://wiki.hacks.guide/wiki/3DS:Things_to_do)!
 {: .notice--info}
 
-{% capture notice-6 %}
-As you may already know, Nintendo is shutting down Nintendo Network services for the Nintendo 3DS and Wii U on April 8th, 2024. This means that online play servers and SpotPass content (e.g. in StreetPass Mii Plaza, Super Mario Maker, and the Pokémon games) will be rendered inaccessible after this date.
-
-The revival service [Pretendo](https://pretendo.network/) is aiming to provide these services after Nintendo shuts down the official one. However, their efforts require the collection of data from Nintendo Network servers in order to understand how they work, which can only be accomplished before the network shutdown.
-
-If you would like to assist with this effort, you can contribute dumps of network data while the official servers are still online.
-- For information about preserving **SpotPass data** (data routed through Nintendo's SpotPass feature), see [the SpotPass Archive project](https://spotpassarchive.github.io/). This project is not affiliated with Pretendo, but provides a more user-friendly instruction and submission format. **SpotPass dumps do not contain any sensitive information.**
-- For information about preserving **game and HTTP packets** (data used by games for servers and other features), see [Pretendo's Network Dumps page](https://pretendo.network/docs/network-dumps). **Please note that this data may contain sensitive information, and that retrieving this data is more technically challenging.**
-{% endcapture %}
-
-<div class="notice--info">{{ notice-6 | markdownify }}</div>
-
 ### Information and Notes
 
 {% capture notice-6 %}

--- a/_pages/en_US/home.txt
+++ b/_pages/en_US/home.txt
@@ -15,7 +15,7 @@ Thoroughly read all of the introductory pages (including this one!) before proce
 {: .notice--info}
 
 {% capture update-notice %}
-{% include_relative include/3ds-11.17.txt %}
+{% include_relative include/3ds-online.txt %}
 {% endcapture %}
 <div class="notice--danger">{{ update-notice | markdownify }}</div>
 

--- a/_pages/en_US/include/3ds-11.17.txt
+++ b/_pages/en_US/include/3ds-11.17.txt
@@ -1,5 +1,0 @@
-**The latest 3DS firmware is 11.17.0**. Here's what you should know:
-
-+ If your console is running *Luma 10.2.1 or higher*, it is *100% safe* to update. You can check your Luma version by holding (Select) while booting your console.
-+ If your console is on an older Luma version, you should [update Luma](checking-for-cfw) before you update your console to 11.17.0.
-+ If your console does not yet have custom firmware, you can install it now on all firmwares with this guide.

--- a/_pages/en_US/include/3ds-online.txt
+++ b/_pages/en_US/include/3ds-online.txt
@@ -1,0 +1,6 @@
+**Nintendo 3DS online services have recently shut down.** Here's what you should know:
+
++ Current 3DS modding methods are not affected.
++ The Internet access of homebrew applications (i.e. Universal-Updater) is not affected.
++ Official online servers are going down for everyone, but alternate online servers (i.e. Pretendo Network) are currently a work-in-progress.
++ Online shutdown does not affect access to the browser or to the Internet. The only thing that has shut down is Nintendo Network online services, such as game servers or friend services.

--- a/_pages/en_US/include/3ds-online.txt
+++ b/_pages/en_US/include/3ds-online.txt
@@ -3,4 +3,4 @@
 + Current 3DS modding methods are not affected.
 + The Internet access of homebrew applications (i.e. Universal-Updater) is not affected.
 + Official online servers are going down for everyone, but alternate online servers (i.e. Pretendo Network) are currently a work-in-progress.
-+ Online shutdown does not affect access to the browser or to the Internet. The only thing that has shut down is Nintendo Network online services, such as game servers or friend services.
++ Online shutdown does not affect access to the browser or to the Internet. The only thing that has shut down is Nintendo Network online services, such as game servers.

--- a/_pages/en_US/key-information.txt
+++ b/_pages/en_US/key-information.txt
@@ -5,7 +5,7 @@ title: "Key Information"
 {% include toc title="Table of Contents" %}
 
 {% capture update-notice %}
-{% include_relative include/3ds-11.17.txt %}
+{% include_relative include/3ds-online.txt %}
 {% endcapture %}
 <div class="notice--danger">{{ update-notice | markdownify }}</div>
 
@@ -58,7 +58,7 @@ If you want, you can check your SD card for errors before following this guide u
 {% capture compat %}
 <summary><strong>Potential risks (Disclaimer)</strong></summary>
 
-By modding your console, you subject it to the remote (but non-zero) possibility of the console being banned from online play or bricked (rendered non-functional). ___Incorrect file placement will NOT brick your console___, but purposely skipping instructions might. Similarly, the last ban wave occurred over five years ago, but there is no guarantee that another one will not occur in the future.
+By modding your console, you subject it to the remote (but non-zero) possibility of the console being bricked (rendered non-functional). ___Incorrect file placement will NOT brick your console___, but purposely skipping instructions might.
 
 In short: Modding your console is safe, but it's ___your responsibility___ if something goes wrong.
 

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -21,7 +21,7 @@ If you change the region of your console:
 
 + You will not be able to use your NNID (if you have one). NNIDs are locked to the region that they were created in.
 + You may not be able to access the eShop, even if you [delete your eShop account](https://en-americas-support.nintendo.com/app/answers/detail/a_id/74/~/how-to-delete-a-nintendo-eshop-account) beforehand. This is because certain titles tend to remain linked to the 3DS, even after account deletion (especially on New 3DS).
-    + This is still relevant because, while purchases can no longer be made on eShop, game updates are still being provided. Updates are usually required for online play.
+    + This is still relevant because, while purchases can no longer be made on eShop, game updates are still being provided. Updates may provide extra content or fix bugs.
     + This logic extends to system transfers, meaning you would not be able to perform a system transfer from a USA 3DS to a region-changed JPN-to-USA 3DS.
     + Pokémon Bank also requires working eShop access.
     + That being said, system transfer and game updates are region locked anyway (e.g. Japanese eShop only has Japanese game updates).

--- a/_pages/en_US/updating-b9s.txt
+++ b/_pages/en_US/updating-b9s.txt
@@ -8,9 +8,6 @@ title: "Updating B9S"
 
 This page is for existing boot9strap users to update their installation of boot9strap to the latest version.
 
-While we believe that custom firmware is safe for online use, there have been online network bans in the past, primarily for cheating and suspicious eShop behavior.
-{: .notice--warning}
-
 ### What You Need
 
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/download/v0.0.7/SafeB9SInstaller-20170605-122940.zip) (direct download)


### PR DESCRIPTION
Do not merge until online services have shut down and it is confirmed that no 3DS update has been released!

- A9LH-to-B9S and Updating B9S: Remove reference to online play (should have done this long ago but I guess we forgor)
- FAQ: Remove reference to CFW working with online play (which no longer exists); keep message about bans in case people still ask
- Homepage, keyinfo, faq: swap out 3ds-11.17 (now gone, it's been almost a year) with 3ds-online
- Key-info: Adjust risks warning to remove reference to online play
- Region changing: Swap out reasoning for game updates
- Finalizing Setup: remove reference to Pretendo network dumps / SpotPass Archive
