### PR TITLE
Correct GBA VC save path

### DIFF
--- a/_pages/en_US/dumping-titles-and-game-cartridges.txt
+++ b/_pages/en_US/dumping-titles-and-game-cartridges.txt
@@ -114,7 +114,7 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
     + Exit the GBA VC game
     + Power off your console
     + Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-    + Navigate to `[0:] SDCARD` -> `gm9`
+    + Navigate to `[0:] SDCARD` -> `gm9` -> `out`
     + Press (Y) on the `<TitleID>.gbavc.sav` file you wish to restore to copy it
     + Press (B) to return to the main menu
     + Navigate to `[S:] SYSNAND VIRTUAL`


### PR DESCRIPTION
**Description**

<!--What does this pull request do? Why is it needed?-->
GBA VC Saves are backed up to 0:/gm9/out, not 0:/gm9