### PR TITLE
Adding the "Fixing DS mode" section into the "Region Changing" guide

### DIFF
--- a/_pages/en_US/include/ctrnand-dsmode.txt
+++ b/_pages/en_US/include/ctrnand-dsmode.txt
@@ -1,0 +1,6 @@
+This section will fix the DS mode from crashing once you try to update the network settings or running DS games on your 3DS/2DS.
+
+1. Open the "Homebrew Launcher" then load "TWLFix-CFW"
+1. Press (A) to begin deleting the DS system files from the previous region 
+1. Once it's completed press (Start) to reboot the system
+1. Update your console for the last time by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"

--- a/_pages/en_US/include/ctrtransfer-prep.txt
+++ b/_pages/en_US/include/ctrtransfer-prep.txt
@@ -6,4 +6,5 @@
 1. Copy the 11.15.0 CTRTransfer image `.bin` from the CTRTransfer `.zip` to the `/gm9/` folder on your SD card
 1. Copy `FBI.3dsx` to the `/3ds/` folder on your SD card
 1. Copy `faketik.3dsx` to the `/3ds/` folder on your SD card
+1. Copy `TWLFix-CFW.3dsx` to the `/3ds/` folder on your SD card
 1. Reinsert your SD card into your console

--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -38,6 +38,7 @@ To download the CTRTransfer images on this page, you will need a torrent client 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
 * The latest release of [FBI](https://github.com/lifehackerhansol/FBI/releases/download/2.6.1/FBI.3dsx) (direct download)
 * The latest release of [faketik](https://github.com/ihaveamac/faketik/releases/latest) *(the `.3dsx` file)*
+* The latest release of [TWLFix-CFW](https://github.com/MechanicalDragon0687/TWLFix-CFW) (required for fixing the DS mode)
 * The 11.15.0 CTRTransfer image for your console type of the region that you want to change to (e.g. Download "New 3DS or 2DS - USA" if you have a New 3DS and want to change your region to USA)
 {% include_relative include/ctrtransfer-images.txt %}
 
@@ -67,6 +68,10 @@ To download the CTRTransfer images on this page, you will need a torrent client 
 #### Section VI - Fixing locale-related issues
 
 {% include_relative include/ctrnand-datayeet.txt %}
+
+#### Section VII - Fixing DS mode
+
+{% include_relative include/ctrnand-dsmode.txt %}
 
 ___
 


### PR DESCRIPTION
**Description**
Heyo. I came here in order to help you and every people who plans to fully region change the console to another region.
The reason of doing this PR is because it's missing the DS mode part. You see, When you try to update the network settings on DS mode from the System Settings, or try to load TWiLight Menu++ or a regular DS game, it crashes and gives you this error shown here:
![20240726_101608](https://github.com/user-attachments/assets/2ae0a63f-2dc5-493f-854c-bd6f064ca31a)

So what I've added in the "Region Changing" guide will cover that part too. For fixing that, [TWLFix-CFW](https://github.com/MechanicalDragon0687/TWLFix-CFW) by MechanicalDragon0687 is required in order to make the DS mode work properly and play DS games on the 3DS/2DS:
![20240726_105238](https://github.com/user-attachments/assets/b638d3d3-2349-412f-9b94-d4e2dcccc3b4)

If you have any questions or sugestions on how can I make it better, let me know and we'll find a solution!

Thank you,
Gabubu