### PR TITLE
super-skaterhax: Change zip from super-skaterhax to release_new3ds

### DIFF
--- a/_pages/en_US/installing-boot9strap-(super-skaterhax).txt
+++ b/_pages/en_US/installing-boot9strap-(super-skaterhax).txt
@@ -35,7 +35,7 @@ In this section, you will copy the files needed to trigger both super-skaterhax 
 1. Insert your SD card into your computer
 1. Copy `boot.firm` and `boot.3dsx` from the Luma3DS `.zip` to the root of your SD card
     + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
-1. Copy everything inside the folder for your console's region and version (`arm11code.bin` and `browserhax_hblauncher_ropbin_payload.bin`) in the super-skaterhax `.zip` to the root of your SD card
+1. Copy everything inside the folder for your console's region and version (`arm11code.bin` and `browserhax_hblauncher_ropbin_payload.bin`) in the release_new3ds `.zip` to the root of your SD card
 1. Create a folder named `boot9strap` on the root of your SD card
 1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your SD card
 1. Copy `SafeB9SInstaller.bin` from the SafeB9SInstaller `.zip` to the root of your SD card


### PR DESCRIPTION
Saw someone get confused about this in assistance since there isn't a zip called super-skaterhax. Not sure how necessary this is since it's my first time seeing this ever, but it can't hurt (or maybe it can, I don't know)