### PR TITLE
CTRTransfer guide makeover

### DIFF
--- a/docs/_include/ctrtransfer-main.md
+++ b/docs/_include/ctrtransfer-main.md
@@ -2,26 +2,14 @@
 1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
 1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
     + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
-1. Navigate to `[0:] SDCARD` -> `gm9`
-1. Press (A) on the CTRTransfer `.bin` to select it
-1. Select "CTRNAND options..."
-1. Select "Transfer image to CTRNAND"
-1. If prompted, select "Transfer to SysNAND"
-    + This prompt will only appear if you have an EmuNAND
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-    + This process will take some time
-1. Once the transfer is completed, press (A) to continue
-1. Press (B) to decline relocking write permissions if prompted
-1. Press (B) twice to return to the main menu
 1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
-1. Select "GM9Megascript"
-1. Select "Scripts from Plailect's Guide"
-1. Select "CTRTransfer Ticket Copy"
-1. When prompted, press (A) to proceed
-1. Press (A) to continue
-1. Press (B) to return to the main menu
-1. Select "Exit"
+1. Select "ctrtransfer"
+1. Select your downloaded CTRTransfer image
+    + The script will calculate the hash of your image to make sure it's valid
+1. Once the checks are completed, press (A) to continue
+1. Press (A) to unlock SysNAND (lvl2) writing, then input the key combo given
+1. Once the transfer is completed, press (A) to continue
 1. Press (A) to relock write permissions if prompted
 1. Press (Start) to reboot your console
 1. Update your console by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"

--- a/docs/_include/ctrtransfer-prep.md
+++ b/docs/_include/ctrtransfer-prep.md
@@ -3,7 +3,9 @@
 1. Create a folder named `3ds` on the root of your SD card if it does not already exist
 1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
 1. Copy the `gm9` folder from the GodMode9 `.zip` to the root of your SD card
-1. Copy the 11.15.0 CTRTransfer image `.bin` from the CTRTransfer `.zip` to the `/gm9/` folder on your SD card
+1. Create a folder named `in` in the `/gm9/` folder if it does not already exist
+1. Copy the 11.15.0 CTRTransfer image `.bin` and `.bin.sha` files from the CTRTransfer `.zip` to the `/gm9/in/` folder on your SD card
+1. Copy `ctrtransfer.gm9` to the `/gm9/scripts/` folder on your SD card
 1. Copy `FBI.3dsx` to the `/3ds/` folder on your SD card
 1. Copy `faketik.3dsx` to the `/3ds/` folder on your SD card
 1. Reinsert your SD card into your console

--- a/docs/ctrtransfer.md
+++ b/docs/ctrtransfer.md
@@ -21,6 +21,7 @@ As a part of this process, your system settings will be reset to its defaults. T
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
 * The latest release of [FBI](https://github.com/nh-server/FBI-NH/releases/download/2.6.1/FBI.3dsx) (direct download)
 * The latest release of [faketik](https://github.com/ihaveamac/faketik/releases/latest) *(the `.3dsx` file)*
+* The latest release of [ctrtransfer.gm9](https://raw.githubusercontent.com/nh-server/scripts/refs/heads/main/3DS/ctrtransfer.gm9) (right click, save link as)
 * A torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download)
     * If you already have a torrent client, you do not need to download a new one
 * The 11.15.0 CTRTransfer image for your console and region:

--- a/docs/ctrtransfer.md
+++ b/docs/ctrtransfer.md
@@ -19,7 +19,7 @@ As a part of this process, your system settings will be reset to its defaults. T
 ## What You Need
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
-* The latest release of [FBI](https://github.com/lifehackerhansol/FBI/releases/download/2.6.1/FBI.3dsx) (direct download)
+* The latest release of [FBI](https://github.com/nh-server/FBI-NH/releases/download/2.6.1/FBI.3dsx) (direct download)
 * The latest release of [faketik](https://github.com/ihaveamac/faketik/releases/latest) *(the `.3dsx` file)*
 * A torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download)
     * If you already have a torrent client, you do not need to download a new one

--- a/docs/region-changing.md
+++ b/docs/region-changing.md
@@ -35,7 +35,7 @@ If you change the region of your console:
 ## What You Need
 
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
-* The latest release of [FBI](https://github.com/lifehackerhansol/FBI/releases/download/2.6.1/FBI.3dsx) (direct download)
+* The latest release of [FBI](https://github.com/nh-server/FBI-NH/releases/download/2.6.1/FBI.3dsx) (direct download)
 * The latest release of [faketik](https://github.com/ihaveamac/faketik/releases/latest) *(the `.3dsx` file)*
 * A torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download)
     * If you already have a torrent client, you do not need to download a new one

--- a/docs/region-changing.md
+++ b/docs/region-changing.md
@@ -37,6 +37,7 @@ If you change the region of your console:
 * The latest release of [GodMode9](https://github.com/d0k3/GodMode9/releases/latest) (the GodMode9 `.zip` file)
 * The latest release of [FBI](https://github.com/nh-server/FBI-NH/releases/download/2.6.1/FBI.3dsx) (direct download)
 * The latest release of [faketik](https://github.com/ihaveamac/faketik/releases/latest) *(the `.3dsx` file)*
+* The latest release of [ctrtransfer.gm9](https://raw.githubusercontent.com/nh-server/scripts/refs/heads/main/3DS/ctrtransfer.gm9) (right click, save link as)
 * A torrent client like [qBittorrent](https://www.qbittorrent.org/download.php) or [Deluge](http://dev.deluge-torrent.org/wiki/Download)
     * If you already have a torrent client, you do not need to download a new one
 * The 11.15.0 CTRTransfer image for your console type of the region that you want to change to (e.g. Download "New 3DS or 2DS - USA" if you have a New 3DS and want to change your region to USA)


### PR DESCRIPTION
**Description**
this pr aims to simplify the ctrtransfer (and region changing) process by doing the following:

- move to a script based tutorial
- merge ctrtransfer ticket copy into said script
- make dirty flashes (flashing without verifying sha hash) impossible by verifying with the script
- make flashing incompatible nands impossible (n3ds nand on o3ds) with the script
- prompting the user if essential console info (such as secinfo) is broken in any way, aborting the transfer (thanks starlit)