### PR TITLE
consoleVersionSelect: add dummy value as first option

### DIFF
--- a/docs/_internal/consoleVersionSelect.html
+++ b/docs/_internal/consoleVersionSelect.html
@@ -11,6 +11,7 @@
 <div id="selectversion" class="selectversion">
     <br>
     <select id="major">
+      <option />
       <option>11</option>
       <option>10</option>
       <option>9</option>
@@ -24,79 +25,83 @@
       <option>1</option>
       <option>0</option>
     </select>.<select id="minor">
-        <option>17</option>
-        <option>16</option>
-        <option>15</option>
-        <option>14</option>
-        <option>13</option>
-        <option>12</option>
-        <option>11</option>
-        <option>10</option>
-        <option>9</option>
-        <option>8</option>
-        <option>7</option>
-        <option>6</option>
-        <option>5</option>
-        <option>4</option>
-        <option>3</option>
-        <option>2</option>
-        <option>1</option>
-        <option>0</option>
+      <option />
+      <option>17</option>
+      <option>16</option>
+      <option>15</option>
+      <option>14</option>
+      <option>13</option>
+      <option>12</option>
+      <option>11</option>
+      <option>10</option>
+      <option>9</option>
+      <option>8</option>
+      <option>7</option>
+      <option>6</option>
+      <option>5</option>
+      <option>4</option>
+      <option>3</option>
+      <option>2</option>
+      <option>1</option>
+      <option>0</option>
     </select>.<select id="whydidnintendodecidetodothingslikethis">
+      <option />
       <option>0</option>
     </select>-<select id="nver">
-        <option>50</option>
-        <option>49</option>
-        <option>48</option>
-        <option>47</option>
-        <option>46</option>
-        <option>45</option>
-        <option>44</option>
-        <option>43</option>
-        <option>42</option>
-        <option>41</option>
-        <option>40</option>
-        <option>39</option>
-        <option>38</option>
-        <option>37</option>
-        <option>36</option>
-        <option>35</option>
-        <option>34</option>
-        <option>33</option>
-        <option>32</option>
-        <option>31</option>
-        <option>30</option>
-        <option>29</option>
-        <option>28</option>
-        <option>27</option>
-        <option>26</option>
-        <option>25</option>
-        <option>24</option>
-        <option>23</option>
-        <option>22</option>
-        <option>21</option>
-        <option>20</option>
-        <option>19</option>
-        <option>18</option>
-        <option>17</option>
-        <option>16</option>
-        <option>15</option>
-        <option>14</option>
-        <option>13</option>
-        <option>12</option>
-        <option>11</option>
-        <option>10</option>
-        <option>9</option>
-        <option>8</option>
-        <option>7</option>
-        <option>6</option>
-        <option>5</option>
-        <option>4</option>
-        <option>3</option>
-        <option>2</option>
-        <option>1</option>
-        <option>0</option>
+      <option />
+      <option>50</option>
+      <option>49</option>
+      <option>48</option>
+      <option>47</option>
+      <option>46</option>
+      <option>45</option>
+      <option>44</option>
+      <option>43</option>
+      <option>42</option>
+      <option>41</option>
+      <option>40</option>
+      <option>39</option>
+      <option>38</option>
+      <option>37</option>
+      <option>36</option>
+      <option>35</option>
+      <option>34</option>
+      <option>33</option>
+      <option>32</option>
+      <option>31</option>
+      <option>30</option>
+      <option>29</option>
+      <option>28</option>
+      <option>27</option>
+      <option>26</option>
+      <option>25</option>
+      <option>24</option>
+      <option>23</option>
+      <option>22</option>
+      <option>21</option>
+      <option>20</option>
+      <option>19</option>
+      <option>18</option>
+      <option>17</option>
+      <option>16</option>
+      <option>15</option>
+      <option>14</option>
+      <option>13</option>
+      <option>12</option>
+      <option>11</option>
+      <option>10</option>
+      <option>9</option>
+      <option>8</option>
+      <option>7</option>
+      <option>6</option>
+      <option>5</option>
+      <option>4</option>
+      <option>3</option>
+      <option>2</option>
+      <option>1</option>
+      <option>0</option>
     </select><select id="region">
+      <option />
       <option>E</option>
       <option>U</option>
       <option>J</option>

--- a/docs/public/assets/js/common.js
+++ b/docs/public/assets/js/common.js
@@ -34,6 +34,10 @@ if (!window.COMMON_LOADED) {
     // CHN/TWN doesn't have new model
     // KOR/CHN/TWN doesn't have 11.17 currently
     c("validate_version", (major, minor, native, region, model) => {
+        // These need to actually exist.
+        if(!major || !minor || !native || !region) {
+            return false;
+        }
         if (model == DEVICE_N3DS && ["C", "T"].includes(region)) {
             return false;
         }


### PR DESCRIPTION
**Description**

This avoids users mindlessly clicking to a potentially invalid page.

Also fixes a bug where the version is marked as valid when empty...

