### PR TITLE
consoleVersionSelect: add version prefix

### DIFF
--- a/docs/_internal/consoleVersionSelect.html
+++ b/docs/_internal/consoleVersionSelect.html
@@ -15,7 +15,7 @@
       <option>Ver.</option>
       <option>Sys.</option>
       <option>Emu.</option>
-      <option>{{ $frontmatter.otherPrefix }}</option>
+      <option>(Other)</option>
     </select>&nbsp;<select id="major">
       <option />
       <option>11</option>

--- a/docs/_internal/consoleVersionSelect.html
+++ b/docs/_internal/consoleVersionSelect.html
@@ -10,7 +10,13 @@
 </table>
 <div id="selectversion" class="selectversion">
     <br>
-    <select id="major">
+    <select id="prefix">
+      <option />
+      <option>Ver.</option>
+      <option>Sys.</option>
+      <option>Emu.</option>
+      <option>{{ $frontmatter.otherPrefix }}</option>
+    </select>&nbsp;<select id="major">
       <option />
       <option>11</option>
       <option>10</option>

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -1,6 +1,7 @@
 ---
 noneSelected: System model is required.
 invalidVersion: This doesn't seem to be a valid system version.
+otherPrefix: (Other)
 head: [
     ['script', {src: '/assets/js/common.js'}],
     ['script', {src: '/assets/js/selecting.js'}]

--- a/docs/public/assets/js/selecting.js
+++ b/docs/public/assets/js/selecting.js
@@ -152,6 +152,7 @@ function can_mset9(major, minor, native, region, model) {
         - All models
 */
 function redirect() {
+    const prefix = document.getElementById("prefix").value;
     const major = document.getElementById("major").value;
     const minor = document.getElementById("minor").value;
     const nver = document.getElementById("nver").value;
@@ -170,13 +171,18 @@ function redirect() {
     if(isO3DS) model = DEVICE_O3DS
     else if(isN3DS) model = DEVICE_N3DS;
 
-    if (!validate_version(major, minor, nver, region, model)) {
+    if (prefix == '' || !validate_version(major, minor, nver, region, model)) {
         document.getElementById("result_invalidVersion").style.display = "block";
         return;
     }
 
     // Store selected version for some later pages
     sessionStorage.setItem("selected_version", JSON.stringify({major, minor, nver, region, model}));
+
+    if(prefix != "Ver.") {
+        window.location.href = "checking-for-cfw";
+        return true;
+    }
 
     const redirected = [
       can_soundhax,


### PR DESCRIPTION

![Screenshot 2025-01-31 143517](https://github.com/user-attachments/assets/2c319dae-06da-403a-b4c6-4e8344bc9132)
If they don't select "Ver.", they have Luma3DS and have skipped the CFW check.

Hopefully, I didn't screw up any translations with my "otherPrefix" thing. Also, I wasn't 100% sure what to call the Ver/Sys/Emu/etc. thing, I think version prefix makes sense though.
