### PR TITLE
Clarify Luma3DS versions in AtoB guide

### DIFF
--- a/docs/a9lh-to-b9s.md
+++ b/docs/a9lh-to-b9s.md
@@ -38,7 +38,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 
 1. Power off your console
 1. Insert your SD card into your computer
-1. Copy everything from Luma3DS `.zip` to the root of your SD card
+1. Copy everything from the latest Luma3DS `.zip` to the root of your SD card
     + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
 1. Copy `arm9loaderhax.bin` from the v7.0.5 Luma3DS `.zip` to the root of your SD card
 1. Copy `SafeB9SInstaller.bin` from the SafeB9SInstaller `.zip` to the `/luma/payloads/` folder on your SD card


### PR DESCRIPTION
Explicitly clarify that the contents of the latest Luma3DS ZIP should be extracted in Step 3 of Section 1 of the AtoB guide.

**Description**

<!--What does this pull request do? Why is it needed?-->

In the AtoB guide (`a9lh-to-b9s.md`), "What You Need" has you download two Luma3DS versions - v7.0.5 (last version compatible with a9lh), and the latest version.

However, in the following section (Prep Work), step 3 is worded ambiguously, and does not clarify which Luma3DS version should be used:

> 3. Copy everything from Luma3DS `.zip` to the root of your SD card

This PR rewords Step 3 to explicitly clarify that the latest Luma3DS ZIP should be used:

> 3. Copy everything from the latest Luma3DS `.zip` to the root of your SD card