### PR TITLE
Fix and tewaks for ssloth

### DIFF
--- a/docs/installing-boot9strap-(ssloth-browser).md
+++ b/docs/installing-boot9strap-(ssloth-browser).md
@@ -55,14 +55,14 @@ In this section, you will visit the browser exploit webpage, which will use univ
 1. On the HOME Menu, press the Left and Right shoulder buttons at the same time to open the camera
     + If you are unable to open the camera, open the Internet Browser and manually type the URL instead (`https://zoogie.github.io/web/nbhax/`)
 1. Tap the QR code button and scan [this QR code](http://api.qrserver.com/v1/create-qr-code/?color=000000&bgcolor=FFFFFF&data=https%3A%2F%2Fzoogie.github.io%2Fweb%2Fnbhax&qzone=1&margin=0&size=400x400&ecc=L)
-    + If you get a crash or an error code, [follow this troubleshooting guide](troubleshooting-ssloth-browser)
-    + If you get a security certificate warning, press (A) to allow the connection
+    + When you get a prompt with error code ``012-1511``, press (A) to allow the connection
+    + If you get a crash or a different error code, [follow this troubleshooting guide](troubleshooting-ssloth-browser)
 
-::: danger
+    ::: danger
 
-If you receive a prompt telling you to update your console, STOP! Redo Section II from the beginning and ensure you have set up the proxy correctly.
+    If you receive a prompt telling you to update your console, STOP! Redo Section II from the beginning and ensure you have set up the proxy correctly.
 
-:::
+    :::
 
 1. Tap the "PROCEED TO HAXX" button
 1. If the exploit was successful, you will have booted into SafeB9SInstaller


### PR DESCRIPTION
* use error code instead of cert warning text
* reword a bit since we'll always get certificate error now
* proper indentation to fix broken ordered list

Should the certificate error be moved into an separate step?
Feel not really ideal since it'll be separated by the warning prompt.