### PR TITLE
Fix confusing wording about replacing the existing files

### DIFF
--- a/docs/a9lh-to-b9s.md
+++ b/docs/a9lh-to-b9s.md
@@ -32,7 +32,7 @@ Note that, only on New 3DS, `secret_sector.bin` is needed to revert the arm9load
 
 ::: info
 
-For all steps in this section, if any of the files already exist, overwrite them with the new files
+For all steps in this section, if any of the files already exist, overwrite them with the new files.
 
 :::
 

--- a/docs/a9lh-to-b9s.md
+++ b/docs/a9lh-to-b9s.md
@@ -32,7 +32,7 @@ Note that, only on New 3DS, `secret_sector.bin` is needed to revert the arm9load
 
 ::: info
 
-For all steps in this section, overwrite any existing files on your SD card.
+For all steps in this section, if any of the files already exist, overwrite them with the new files
 
 :::
 

--- a/docs/godmode9-usage.md
+++ b/docs/godmode9-usage.md
@@ -24,7 +24,7 @@ GodMode9 is powerful software that has the capability to modify essentially anyt
 
 ::: info
 
-Some of the instructions below are only applicable to the latest version of GodMode9, and as such you should follow this section to update your copy before continuing. Overwrite any existing files.
+Some of the instructions below are only applicable to the latest version of GodMode9, and as such you should follow this section to update your copy before continuing. If any of the files exist, overwrite them with the new files
 
 :::
 

--- a/docs/godmode9-usage.md
+++ b/docs/godmode9-usage.md
@@ -24,7 +24,7 @@ GodMode9 is powerful software that has the capability to modify essentially anyt
 
 ::: info
 
-Some of the instructions below are only applicable to the latest version of GodMode9, and as such you should follow this section to update your copy before continuing. If any of the files exist, overwrite them with the new files
+Some of the instructions below are only applicable to the latest version of GodMode9, and as such you should follow this section to update your copy before continuing. If any of the files exist, overwrite them with the new files.
 
 :::
 

--- a/docs/installing-boot9strap-(mset9-cli).md
+++ b/docs/installing-boot9strap-(mset9-cli).md
@@ -34,7 +34,7 @@ On this page, you will use the MSET9 script, which is used to trigger MSET9. Whi
 In this section, you will prepare the MSET9 exploit by **temporarily** creating a new HOME Menu profile with almost no user data, and then setting up that profile with only the minimum data required for MSET9 to trigger. Your existing user data will disappear, but will come back when you are finished with this page.
 
 1. Insert your SD card into your computer
-1. Copy everything from the MSET9 `.zip` to the root of your SD card, overwriting any existing files
+1. Copy everything from the MSET9 `.zip` to the root of your SD card. If any of the files exist, overwrite them with the new files.
 
     ::: info
 

--- a/docs/installing-boot9strap-(mset9-play-store).md
+++ b/docs/installing-boot9strap-(mset9-play-store).md
@@ -35,7 +35,7 @@ On Android phones/tablets, the minimum Android version required is 6.0 (Marshmal
 In this section, you will prepare the MSET9 exploit by **temporarily** creating a new HOME Menu profile with almost no user data, and then setting up that profile with only the minimum data required for MSET9 to trigger. Your existing user data will disappear, but will come back when you are finished with this page.
 
 1. Insert your SD card into your phone/tablet/computer
-1. Copy everything from the MSET9 `.zip` to the root of your SD card, overwriting any existing files:
+1. Copy everything from the MSET9 `.zip` to the root of your SD card. If any of the files exist, overwrite them with the new files:
     + Open ZArchiver
     + If prompted, [allow ZArchiver to access files on your SD card](/images/screenshots/mset9/zarchiver-allow.png)
     + Navigate to where the downloaded MSET9 `.zip` is located ([likely in the Downloads folder](/images/screenshots/mset9/zarchiver-zip-location.png))

--- a/docs/installing-boot9strap-(super-skaterhax).md
+++ b/docs/installing-boot9strap-(super-skaterhax).md
@@ -34,7 +34,7 @@ In this section, you will copy the files needed to trigger both super-skaterhax 
 
 1. Power off your console
 1. Insert your SD card into your computer
-1. Copy everything from the Super-skaterhax `.zip` to the root of your SD card, If any of the files exist, overwrite them with the new files.
+1. Copy everything from the Super-skaterhax `.zip` to the root of your SD card. If any of the files exist, overwrite them with the new files.
     ::: info
 
     ![](/images/screenshots/skaterhax/skater-root-layout.png)

--- a/docs/installing-boot9strap-(super-skaterhax).md
+++ b/docs/installing-boot9strap-(super-skaterhax).md
@@ -34,8 +34,7 @@ In this section, you will copy the files needed to trigger both super-skaterhax 
 
 1. Power off your console
 1. Insert your SD card into your computer
-1. Copy everything from the Super-skaterhax `.zip` to the root of your SD card, overwriting any existing files
-
+1. Copy everything from the Super-skaterhax `.zip` to the root of your SD card, If any of the files exist, overwrite them with the new files.
     ::: info
 
     ![](/images/screenshots/skaterhax/skater-root-layout.png)

--- a/docs/restoring-updating-cfw.md
+++ b/docs/restoring-updating-cfw.md
@@ -13,7 +13,7 @@ Your SD card must be formatted as FAT32 to follow this guide, or else the 3DS wi
 ## Instructions
 
 1. Insert your SD card into your computer
-1. Copy everything from the Luma3DS `.zip` (`boot.firm`, `boot.3dsx`, and `config`) to the root of your SD card. If any of the files exist, overwrite them with the new files
+1. Copy everything from the Luma3DS `.zip` (`boot.firm`, `boot.3dsx`, and `config`) to the root of your SD card. If any of the files exist, overwrite them with the new files.
     + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
 1. Reinsert your SD card into your console
 1. Power on your console

--- a/docs/restoring-updating-cfw.md
+++ b/docs/restoring-updating-cfw.md
@@ -13,7 +13,7 @@ Your SD card must be formatted as FAT32 to follow this guide, or else the 3DS wi
 ## Instructions
 
 1. Insert your SD card into your computer
-1. Copy everything from the Luma3DS `.zip` (`boot.firm`, `boot.3dsx`, and `config`) to the root of your SD card, replacing any existing files
+1. Copy everything from the Luma3DS `.zip` (`boot.firm`, `boot.3dsx`, and `config`) to the root of your SD card. If any of the files exist, overwrite them with the new files
     + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
 1. Reinsert your SD card into your console
 1. Power on your console


### PR DESCRIPTION
**Description**

changed wording about replacing files on a couple of pages as the current wording is confusing to some. changed wording to "If any of the files exist, overwrite them with the new files" from "overwrite any existing files"
