### PR TITLE
Already have CFW

### DIFF
--- a/docs/already-have-cfw.md
+++ b/docs/already-have-cfw.md
@@ -1,0 +1,52 @@
+# Already have CFW
+
+## Required Reading
+
+Your console already has custom firmware installed. This may not be obvious, as custom firmware is often invisible in day-to-day usage.
+
+This section will help you determine how to upgrade your custom firmware setup.
+
+::: info
+
+If your console has a menuhax-based CFW setup, you should [clear HOME Menu's extdata](troubleshooting-post-install), then follow all instructions on your SysNAND. You probably have a menuhax-based setup if your system version when booting without an SD card is 9.2.0-20.
+
+:::
+
+## Instructions
+
+1. Power off your console
+1. Hold the (Select) button
+1. Power on your console while still holding the (Select) button
+1. You should now see a configuration menu of some sort
+
+## What to do next
+
+::: tip
+
+If you see a Luma3DS version of 7.0.5 or lower, continue to [A9LH to B9S](a9lh-to-b9s)
+
+:::
+
+::: tip
+
+If you see a Luma3DS version of 7.1, continue to [Updating B9S](updating-b9s)
+
+:::
+
+::: tip
+
+If you see a Luma3DS version of 8.0 or greater, continue to [Restoring / Updating CFW](restoring-updating-cfw)
+
+:::
+
+::: warning
+
+If you see GodMode9, Decrypt9WIP, Hourglass9, or Luma3DS chainloader, you held (Start) by accident and should try these instructions again with (Select)
+
+:::
+
+::: danger
+
+If your console boots to the normal HOME menu or you see something not described by the above options, join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and ask, in English, for help.
+
+:::

--- a/docs/public/assets/js/selecting.js
+++ b/docs/public/assets/js/selecting.js
@@ -180,7 +180,7 @@ function redirect() {
     sessionStorage.setItem("selected_version", JSON.stringify({major, minor, nver, region, model}));
 
     if(prefix != "Ver.") {
-        window.location.href = "checking-for-cfw";
+        window.location.href = "already-have-cfw";
         return true;
     }
 

--- a/docs/site-navigation.md
+++ b/docs/site-navigation.md
@@ -33,6 +33,7 @@
 **All**
 
 + [A9LH to B9S](a9lh-to-b9s)
++ [Already have CFW](already-have-cfw)
 + [Credits](credits)
 + [Checking for CFW](checking-for-cfw)
 + [Contribute](contribute)


### PR DESCRIPTION
This page is similar to Checking for CFW except it tells you outright that you have custom firmware and redirects you to the Discord server for assistance if you boot to the HOME menu (in cases of broken buttons or Stealth Luma or something).

Why?

1. "Solves" #2568
2. Allows us to get a .alreadycfw command (or something like that) so people are less confused when giving support. (No more "but I already have CFW installed" when sending .cfwcheck)