### PR TITLE
Replace guiformat with Rufus in +64GB SD formatting documentation

### DIFF
--- a/docs/formatting-sd-(windows).md
+++ b/docs/formatting-sd-(windows).md
@@ -11,7 +11,7 @@ This page is for Windows users only. If you are not on Windows, check out the [F
 ## What You Need
 
 * **For all SD card sizes**: The latest version of [SD Formatter](https://www.sdcard.org/downloads/formatter/sd-memory-card-formatter-for-windows-download/)
-* **For SD cards 64GB or larger only:** The latest version of [guiformat](http://ridgecrop.co.uk/index.htm?guiformat.htm)
+* **For SD cards 64GB or larger only:** The latest version of [Rufus](https://rufus.ie)
 
 ## Instructions
 
@@ -44,10 +44,10 @@ You're done formatting your SD card if it's **32GB or smaller.**
 
 :::
 
-### Section II - guiformat (ONLY for 64GB or larger)
+### Section II - Rufus (ONLY for 64GB or larger)
 
-1. Run `guiformat.exe`
-1. Select your SD card's drive letter for "Drive"
+1. Run `Rufus-X.X` (the `.exe` file and where `X.X` is the version) and run the program.
+1. Select your SD card's drive at "Device".
 
     ::: danger
 
@@ -55,25 +55,22 @@ You're done formatting your SD card if it's **32GB or smaller.**
 
     :::
 
-1. Select a size for "Allocation unit size"
-    + If the SD card is 64GB, choose 32768
-    + If the SD card is larger than 64GB, choose 65536
-1. Enter anything for "Volume label"
-1. Ensure that "Quick Format" is selected
-1. Click "Start"
-1. Click "OK"
-1. Wait for the format to finish
+1. Under "Boot selection", select "Non bootable".
+1. Under "Partition scheme", select "MBR".
+1. Enter any name you want in "Volume label".
+1. Under "File system", select "FAT32".
+1. Under "Cluster size", choose:
+    + 32 kilobytes if the SD card is 64GB.
+    + 64 kilobytes if the SD card is larger than 64GB.
+1. Click "START"
+1. Confirm by clicking "OK"
+1. Wait for the formatting process to complete.
 1. Click "Close"
-1. If the SD card had any files and folders on it before the format, copy everything back from your computer
+1. Open File Explorer.
+1. Navigate to your formatted SD card.
+1. Delete the files that Rufus created in it.
 
 ## Troubleshooting
-
-* guiformat shows the error "Failed to open device: GetLastError()=32"
-    + Close everything that may be using the SD card, such as any File Explorer windows.
-    + If this issue persists, try reformatting the card to NTFS in File Explorer, close that window when it's done, and re-attempt the guiformat process.
-
-* guiformat shows the error "GetLastError()=1117"
-    + Your SD card write-protection switch may be [enabled](/images/sdlock.png). The lock must be flipped upwards to allow writing to the SD card (including formatting).
 
 * SD card remains undetected by console or continues to display the wrong capacity after formatting
     + Your SD card may be partitioned or have unallocated space. Follow the instructions [here](https://wiki.hacks.guide/wiki/SD_Clean/Windows) to reformat your SD card.

--- a/docs/formatting-sd-(windows).md
+++ b/docs/formatting-sd-(windows).md
@@ -69,6 +69,7 @@ You're done formatting your SD card if it's **32GB or smaller.**
 1. Open File Explorer.
 1. Navigate to your formatted SD card.
 1. Delete the files that Rufus created in it.
+1. If the SD card had any files and folders on it before the format, copy everything back from your computer.
 
 ## Troubleshooting
 


### PR DESCRIPTION
**Description**

guiformat does not provide an option to select the MBR partition table, which caused issues when formatting SD cards configured with GPT. This commit updates the documentation to use Rufus, which allows selecting the partition scheme (MBR/GPT)
