### PR TITLE
Add platform warning to base MSET9 page.

### DIFF
--- a/docs/installing-boot9strap-(mset9).md
+++ b/docs/installing-boot9strap-(mset9).md
@@ -6,6 +6,12 @@ The instructions for MSET9 differ depending on the computer, phone, or tablet **
 
 Choose the operating system of the device **that you will be using to mod your console**. The device will need a way to read and write files onto the 3DS SD card.
 
+::: warning
+
+This method requires either a computer running Windows, Linux, or macOS, or an Android phone/tablet or Chromebook. If you do not have access to any of these devices, you will need to use an [alternate exploit](https://wiki.hacks.guide/wiki/3DS:Alternate_Exploits).
+
+:::
+
 | Windows, macOS, Linux | Android, ChromeOS |
 |:-:|:-:|
 | [![Windows](/images/windows.png)](installing-boot9strap-(mset9-cli)) <br><br> [![macOS](/images/macos.png)](installing-boot9strap-(mset9-cli)) <br><br> [![Linux](/images/linux.png)](installing-boot9strap-(mset9-cli)) | [![Android](/images/android.png)](installing-boot9strap-(mset9-play-store)) <br><br> [![chromeOS](/images/chromeos.png)](installing-boot9strap-(mset9-play-store)) |


### PR DESCRIPTION
I noticed while checking the base MSET9 page that platforms like iOS aren't listed, _but_ that the warning about "not having access to any of these devices" only appears _after_ you select the platform on the base MSET9 page, which doesn't necessarily seem ideal (since what platform would you select if you're using iOS on the base MSET9 page? (which doesn't currently have this warning)).

This PR attempts to fix this by simply adding a variant of the same wording to the base MSET9 page.

(Note: It might be better to just say "If your platform isn't listed here" at the start, but as that could _potentially_ be more confusing depending on how somebody looks at that, I'll defer to the other people looking at this PR as to whether or not that wording would make more sense.)
