### PR TITLE
Updated the price of the Ace 3DSX flashcart.

### DIFF
--- a/docs/ntrboot.md
+++ b/docs/ntrboot.md
@@ -16,7 +16,7 @@ Note that carts with a "Time Bomb" will no longer be able to launch `.nds` files
 
 | Flashcart Name | Current Price | "Time Bomb"? | 3DS Versions? | DSi Versions? | Other Notes |
 |-|-:|:-:|:-:|:-:|-|
-| [**Ace3DS X**](https://www.nds-card.com/ProShow.asp?ProID=575) | $17.99 | No | ALL | ALL | **Comes pre-flashed with ntrboot** (external switch to switch between ntrboot ("3DS") and NDS modes); do not manually flash with ntrboot. This cart needs an SD card inserted to function for both ntrboot and regular NDS firmware. |
+| [**Ace3DS X**](https://www.nds-card.com/ProShow.asp?ProID=575) | $24.99 | No | ALL | ALL | **Comes pre-flashed with ntrboot** (external switch to switch between ntrboot ("3DS") and NDS modes); do not manually flash with ntrboot. This cart needs an SD card inserted to function for both ntrboot and regular NDS firmware. |
 | [**R4i-SDHC B9S** (r4i-sdhc.com)](http://www.nds-card.com/ProShow.asp?ProID=574) | $16.99 | September 3, 2024 | ALL | ALL | **Comes pre-flashed with ntrboot**; can be flashed back to an NDS flashcart. |
 | [**DSTT** (ndstt.com)](http://www.nds-card.com/ProShow.asp?ProID=157) | $11.99 | No | None | None | Only models with [certain flash chips](https://gist.github.com/aspargas2/fa2a70aed3a7fe33f1f10bc264d9fab6) are compatible with ntrboot. |
 | [**R4i-SDHC 3DS RTS** (r4i-sdhc.com)](http://www.nds-card.com/ProShow.asp?ProID=146) | $15.99 | 1.85b: September 3, 2024 | ALL | ALL | |


### PR DESCRIPTION
The listing on nds-card.com shows a "New price" of $24.99 (US).

**Description**

The pull request updates the price of purchasing an Ace 3DSX ntrboot flashcart from $17.99 to $24.99. It ensures that a user isn't surprised when they see that a flashcart is more expensive than what was listed on the guide.