### PR TITLE
Fix the outdated f3 releases link

### DIFF
--- a/docs/f3-(linux).md
+++ b/docs/f3-(linux).md
@@ -10,7 +10,7 @@ This page is for Linux users only. If you are not on Linux, check out the [H2tes
 
 ## What You Need
 
-* The latest version of [F3](https://github.com/AltraMayor/f3/releases/tag/v8.0)
+* The latest version of [F3](https://github.com/AltraMayor/f3/releases/latest)
 
 ## Instructions
 


### PR DESCRIPTION
**Description**

The latest `f3` version for linux is `v9.0`.
This change could be alternatively done as `releases/tag/v9.0` instead, but I've noticed pages for other sd card checking tools already use `releases/latest` so I've decided to use this here too for consistency.
