### PR TITLE
mset9: miscellaneous changes

### DIFF
--- a/docs/installing-boot9strap-(mset9-cli-ios).md
+++ b/docs/installing-boot9strap-(mset9-cli-ios).md
@@ -81,7 +81,7 @@ In this section, you will prepare the MSET9 exploit by **temporarily** creating 
 
     + If the screen says [Not ready - check MSET9 status for more details](/images/screenshots/mset9/mset9-ish-not-ready.png):
         + Type `2`, then tap Return to check the MSET9 status and follow the directions indicated
-        + Once you have resolved the issue, return to Section I Step 14
+        + Once you have resolved the issue, return to Section I Step 16
         + For more information, check the [troubleshooting](troubleshooting-mset9) page
 1. Type `0`, then tap Return to close the script
 1. Reinsert your SD card into your console

--- a/docs/troubleshooting-mset9.md
+++ b/docs/troubleshooting-mset9.md
@@ -1,6 +1,6 @@
 # Troubleshooting (MSET9)
 
-This page offers troubleshooting advice for commonly encountered issues with the "Installing boot9strap (MSET9)", "Installing boot9strap (MSET9 CLI)" and "Installing boot9strap (MSET9 Play Store)" pages. If you are unable to solve your issue with the advice on this page, please join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and describe your issue, including what you have already tried.
+This page offers troubleshooting advice for commonly encountered issues with the "Installing boot9strap (MSET9 CLI)", "Installing boot9strap (MSET9 Play Store)", and "Installing boot9strap (MSET9 CLI iOS) pages. If you are unable to solve your issue with the advice on this page, please join [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp) and describe your issue, including what you have already tried.
 
 ## MSET9 (application / script)
 
@@ -16,7 +16,7 @@ The pyfatfs module, which is needed to use the MSET9 installer on macOS, isn't i
 
 1. Open a separate Terminal window
 1. Type `python3 -m pip install pyfatfs`, then press Enter
-1. Start again from [Section I Step 3](installing-boot9strap-(mset9-cli)#section-i---prep-work)
+1. Start again from [Section I Step 3](installing-boot9strap-(mset9-cli)#section-i-prep-work)
 
 :::
 
@@ -29,7 +29,7 @@ If this does not work, your SD card needs to be formatted:
 1. Copy everything off the SD Card to your PC
 1. Format the SD Card ([Windows](formatting-sd-(windows)), [Linux](formatting-sd-(linux)), [macOS](formatting-sd-(mac)))
 1. Copy everything back
-1. Start again from [Section I Step 7](installing-boot9strap-(mset9-cli)#section-i---prep-work)
+1. Start again from [Section I Step 7](installing-boot9strap-(mset9-cli)#section-i-prep-work)
 
 :::
 
@@ -42,7 +42,7 @@ If this does not work, your SD card needs to be formatted:
 1. Copy everything off the SD Card to your PC
 1. Format the SD Card ([Windows](formatting-sd-(windows)), [Linux](formatting-sd-(linux)), [macOS](formatting-sd-(mac)))
 1. Copy everything back
-1. Start again from [Section I Step 8](installing-boot9strap-(mset9-cli)#section-i---prep-work).
+1. Start again from [Section I Step 8](installing-boot9strap-(mset9-cli)#section-i-prep-work).
 
 :::
 
@@ -52,7 +52,7 @@ Ensure that you have reset the title database.
 + Please power on your console with your SD inserted 
 + Launch System Settings and navigate to `Data Management` -> `Nintendo 3DS` -> `Software` -> Reset ([image](/images/screenshots/database-reset.jpg))
     + This will not wipe any of your data
-+ If you get a reset prompt, after resetting, power off your console and start again from [Section I Step 14](installing-boot9strap-(mset9-cli)#section-i---prep-work)
++ If you get a reset prompt, after resetting, power off your console and start again from [Section I Step 14](installing-boot9strap-(mset9-cli)#section-i-prep-work)
 
 If you do *not* getting a reset prompt, your SD card needs to be formatted:
 
@@ -64,7 +64,7 @@ If you do *not* getting a reset prompt, your SD card needs to be formatted:
 1. Type `2` then press enter to check the MSET9 status
     + This will create the dummy databases again
 1. Close the MSET9 script window
-1. Start again from [Section I Step 12](installing-boot9strap-(mset9-cli)#section-i---prep-work).
+1. Start again from [Section I Step 12](installing-boot9strap-(mset9-cli)#section-i-prep-work).
 
 :::
 
@@ -85,7 +85,7 @@ If your SD card layout is correct, then your SD card most likely isn't being rea
 1. Copy everything off the SD Card to your PC
 1. Format the SD Card ([Windows](formatting-sd-(windows)), [Linux](formatting-sd-(linux)), [macOS](formatting-sd-(mac)))
 1. Copy everything back
-1. Start again from the beginning of [Section I](installing-boot9strap-(mset9-cli)#section-i---prep-work)
+1. Start again from the beginning of [Section I](installing-boot9strap-(mset9-cli)#section-i-prep-work)
 
 ::::
 
@@ -113,7 +113,7 @@ You have multiple ID0 folders. To determine the correct folder, follow these ins
 1. Move the true ID0 folder from the `BACKUP_Nintendo 3DS` folder to the `Nintendo 3DS` folder
 1. If it exists, move the `Private` folder from the `BACKUP_Nintendo 3DS` folder to the `Nintendo 3DS` folder
 
-Once you've done this, continue from [Section I Step 3](installing-boot9strap-(mset9-cli)#section-i---prep-work).
+Once you've done this, continue from [Section I Step 3](installing-boot9strap-(mset9-cli)#section-i-prep-work).
 
 :::
 
@@ -154,19 +154,19 @@ You may be missing `SafeB9S.bin` from the root of your SD card, or the file may 
 <!--@include: ./_include/mset9-chorus.md -->
 1. Type the number corresponding to your console model and version, then press Enter
     + The current state should display [Injected](/images/screenshots/mset9/mset9-injected.png)
-    + If you have already removed the trigger file (or never injected in the first place), the current state will show [Ready](/images/screenshots/mset9/mset9-ready.png), and you may [retry Section II](installing-boot9strap-(mset9-cli)#section-ii---mset9)
+    + If you have already removed the trigger file (or never injected in the first place), the current state will show [Ready](/images/screenshots/mset9/mset9-ready.png), and you may [retry Section II](installing-boot9strap-(mset9-cli)#section-ii-mset9)
 1. Type `4`, then press Enter
 1. Once the window says "Removed trigger file", type `0` and then press Enter
 1. Reinsert the SD card into your console
 1. Power on your console
-1. Return to [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii---mset9)
+1. Return to [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii-mset9)
 
 Alternatively, your SD card may be improperly formatted or partitioned. After removing the trigger file, format it:
 
 1. Copy everything off the SD Card to your PC
 1. Format the SD Card ([Windows](formatting-sd-(windows)), [Linux](formatting-sd-(linux)), [macOS](formatting-sd-(mac)))
 1. Copy everything back
-1. Start again from from [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii---mset9)
+1. Start again from from [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii-mset9)
 
 :::
 
@@ -186,14 +186,14 @@ Follow these instructions to remove the trigger file and to retry Section II:
 1. Once the window says "Removed trigger file", type `0` and then press Enter
 1. Reinsert the SD card into your console
 1. Power on your console
-1. Return to [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii---mset9)
+1. Return to [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii-mset9)
 
 If you continue to have this issue and are sure that you did everything correctly, ensure the trigger file is removed and format your SD card:
 
 1. Copy everything off the SD Card to your PC
 1. Format the SD Card ([Windows](formatting-sd-(windows)), [Linux](formatting-sd-(linux)), [macOS](formatting-sd-(mac)))
 1. Copy everything back
-1. Start again from from [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii---mset9)
+1. Start again from from [Section II Step 1](installing-boot9strap-(mset9-cli)#section-ii-mset9)
 
 :::
 
@@ -219,6 +219,12 @@ Go back to [Installing boot9strap (MSET9 CLI)](installing-boot9strap-(mset9-cli)
 ::: tip
 
 Go back to [Installing boot9strap (MSET9 Play Store)](installing-boot9strap-(mset9-play-store))
+
+:::
+
+::: tip
+
+Go back to [Installing boot9strap (MSET9 CLI IOS)](installing-boot9strap-(mset9-cli-ios))
 
 :::
 


### PR DESCRIPTION
Fix the step number of where to restart from in MSET9 CLI iOS
Mention every MSET9 page in the troubleshooting MSET9 header
Fix the section links in troubleshooting MSET9
Add MSET9 CLI iOS to the return footer of troubleshooting MSET9
