### PR TITLE
Bring back cookieconsent

### DIFF
--- a/docs/.vitepress/config.mjs
+++ b/docs/.vitepress/config.mjs
@@ -15,6 +15,23 @@ export default defineConfig({
   description: "A complete guide to 3DS custom firmware",
   head: [
     ['link', { rel: 'icon', href: '/images/site-config/favicon.ico' }],
+    ['link', {
+      rel: 'stylesheet',
+      href: 'https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.css',
+      integrity: "sha512-LQ97camar/lOliT/MqjcQs5kWgy6Qz/cCRzzRzUCfv0fotsCTC9ZHXaPQmJV8Xu/PVALfJZ7BDezl5lW3/qBxg==",
+      crossorigin: "anonymous",
+      referrerpolicy: "no-referrer"
+    }],
+    ['script', {
+      src: 'https://cdnjs.cloudflare.com/ajax/libs/cookieconsent2/3.1.1/cookieconsent.min.js',
+      integrity: "sha512-yXXqOFjdjHNH1GND+1EO0jbvvebABpzGKD66djnUfiKlYME5HGMUJHoCaeE4D5PTG2YsSJf6dwqyUUvQvS0vaA==",
+      crossorigin: "anonymous",
+      referrerpolicy: "no-referrer"
+    }],
+    ['link', {
+      rel: 'stylesheet',
+      href: '/assets/css/cookieconsent.css'
+    }],
     ['script', { async: '', src: 'https://www.googletagmanager.com/gtag/js?id=G-760Y60FQ3T' }],
     ['script', {}, `window.dataLayer = window.dataLayer || []; function gtag(){dataLayer.push(arguments);}gtag('js', new Date());gtag('config', 'G-760Y60FQ3T');`]
   ],

--- a/docs/.vitepress/i18n/en_US.js
+++ b/docs/.vitepress/i18n/en_US.js
@@ -269,5 +269,14 @@ export default {
 	label: "English",
     title: localeData.title,
     description: localeData.description,
-    themeConfig: themeConfig
+    themeConfig: themeConfig,
+	head: [
+		['script',
+			{
+				id: "cookieconsent_i18n",
+				content: localeData.cookieConsent,
+				src: "/assets/js/cookieconsent.js"
+			},
+		]
+	],
 }

--- a/docs/.vitepress/i18n/strings/en_US.json
+++ b/docs/.vitepress/i18n/strings/en_US.json
@@ -7,6 +7,7 @@
     "lightModeSwitchTitle": "Switch to light theme",
     "sidebarMenuLabel": "Menu",
     "returnToTopLabel": "Return to top",
+    "cookieConsent": "This website uses cookies to display the current guide progress on the sidebar and otherwise enhance the site.",
 
     "guide": "Guide",
     "extras": "Extras",

--- a/docs/public/assets/css/cookieconsent.css
+++ b/docs/public/assets/css/cookieconsent.css
@@ -1,0 +1,30 @@
+.cc-window {
+    color: var(--vp-c-text-1);
+    background-color: var(--vp-c-gray-1);
+}
+
+.cc-link {
+    color: var(--vp-c-brand-1);
+}
+
+.cc-link:visited {
+    color: var(--vp-c-brand-1);
+}
+
+.cc-floating {
+  border: 2px solid var(--vp-c-border);
+}
+
+.cc-btn {
+  font-weight: bold;
+  font-size: 100%;
+  cursor: pointer;
+  border: 2px solid var(--vp-c-border);
+  padding: .25em;
+  border-radius: 4px;
+  appearance: auto;
+}
+
+.cc-btn:hover {
+  background-color: var(--vp-c-gray-3);
+}

--- a/docs/public/assets/js/cookieconsent.js
+++ b/docs/public/assets/js/cookieconsent.js
@@ -1,0 +1,8 @@
+window.addEventListener("load", function(){
+window.cookieconsent.initialise({
+  "theme": "classic",
+  "position": "bottom-right",
+  "content": {
+    "message": document.getElementById("cookieconsent_i18n").getAttribute("content")
+  }
+})});


### PR DESCRIPTION
**Description**

It was removed during the transition to VitePress. We do need to add it back given the structure of the site.

The old plugin is back, but with some changes:
- instead of static banner at top, it is a floating box on the bottom right
- a custom CSS override was added to adapt the theming of the box to VitePress
- make translatable by adding a locale-specific head that imports the JS file with a hack to add custom parameters for the message content
- minor rice

For now this is only added to the English page. As the translations for it start to fill, we can enable for remaining languages.

