### PR TITLE
Use <kbd> tags to represent console buttons

### DIFF
--- a/docs/_include/configure-luma3ds.md
+++ b/docs/_include/configure-luma3ds.md
@@ -2,4 +2,4 @@
     + Luma3DS configuration menu are settings for the Luma3DS custom firmware. Many of these settings may be useful for customization or debugging
     + For the purpose of this guide, **leave these options on the default settings** (do not check or uncheck anything)
     + If your console displays a white notification LED and shuts down when you try to power it on, ensure that you have [Luma3DS's `boot.firm`](https://github.com/LumaTeam/Luma3DS/releases/latest) on the root of SD card (inside `Luma3DSvX.X.X.zip`)
-1. Press (Start) to save and reboot
+1. Press <kbd>Start</kbd> to save and reboot

--- a/docs/_include/configure-luma3ds.md
+++ b/docs/_include/configure-luma3ds.md
@@ -2,4 +2,4 @@
     + Luma3DS configuration menu are settings for the Luma3DS custom firmware. Many of these settings may be useful for customization or debugging
     + For the purpose of this guide, **leave these options on the default settings** (do not check or uncheck anything)
     + If your console displays a white notification LED and shuts down when you try to power it on, ensure that you have [Luma3DS's `boot.firm`](https://github.com/LumaTeam/Luma3DS/releases/latest) on the root of SD card (inside `Luma3DSvX.X.X.zip`)
-1. Press <kbd>Start</kbd> to save and reboot
+1. Press <kbd>START</kbd> to save and reboot

--- a/docs/_include/ctrnand-datayeet.md
+++ b/docs/_include/ctrnand-datayeet.md
@@ -13,19 +13,19 @@ This process will reset your Mii data. If you wish to save any Miis that you hav
 :::
 
 1. Power off your console
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[1:] SYSNAND CTRNAND` -> `data` -> `<ID0>` -> `sysdata`
     + The `<ID0>` will be a folder with a 32-character long name
 1. Use the D-Pad to highlight `00010017`
-1. Press (Right Shoulder) + (A) to bring up the folder options
+1. Press <kbd>R+A</kbd> to bring up the folder options
 1. Select "Copy to 0:/gm9/out"
-1. Press (A) to continue
-1. While still highlighting `00010017`, press (X) to delete it
-1. Press (A) to confirm
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-1. Once the file has been deleted, press (A) to continue
-1. Press (A) to relock write permissions if prompted
-1. Press (Start) to reboot your console
+1. Press <kbd>A</kbd> to continue
+1. While still highlighting `00010017`, press <kbd>X</kbd> to delete it
+1. Press <kbd>A</kbd> to confirm
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Once the file has been deleted, press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to relock write permissions if prompted
+1. Press <kbd>START</kbd> to reboot your console
 1. Your console will load into the initial setup menu
     + This is expected behaviour. You have not lost any of your game data
 1. Complete the initial setup menu by following the prompts on your console's screen

--- a/docs/_include/ctrtransfer-main.md
+++ b/docs/_include/ctrtransfer-main.md
@@ -1,20 +1,20 @@
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
-1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. If you are prompted to create an essential files backup, press <kbd>A</kbd> to do so, then press <kbd>A</kbd> to continue once it is completed
+1. If you are prompted to fix the RTC date&time, press <kbd>A</kbd> to do so, then set the date and time, then press <kbd>A</kbd> to continue
     + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
 1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
 1. Select "ctrtransfer"
 1. Select your downloaded CTRTransfer image
     + The script will calculate the hash of your image to make sure it's valid
-1. Once the checks are completed, press (A) to continue
-1. Press (A) to unlock SysNAND (lvl2) writing, then input the key combo given
-1. Once the transfer is completed, press (A) to continue
-1. Press (A) to relock write permissions if prompted
-1. Press (Start) to reboot your console
+1. Once the checks are completed, press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl2) writing, then input the key combo given
+1. Once the transfer is completed, press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to relock write permissions if prompted
+1. Press <kbd>START</kbd> to reboot your console
 1. Update your console by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
     + Updates while using B9S + Luma (what you have) are safe
-    + If this gives you an error, set your DNS settings to "auto"
+    + If this gives you an error, set your DNS settings to "Auto"
         + Pretendo users: Switch to Nintendo Network in Nimbus
 
 ::: info

--- a/docs/_include/ctrtransfer-ticket-copy.md
+++ b/docs/_include/ctrtransfer-ticket-copy.md
@@ -14,9 +14,9 @@ If the script found no user tickets, continue to the next section.
     + Select "\<current directory>"
     + Select "Install and delete all tickets"
     + Wait. The system may appear to freeze, just give it time.
-    + Press (A) to confirm
-    + Press (B) to decline installing tickets from CDN.
-1. Press (Home) to exit FBI
+    + Press <kbd>A</kbd> to confirm
+    + Press <kbd>B</kbd> to decline installing tickets from CDN.
+1. Press <kbd>HOME</kbd> to exit FBI
 1. Re-open the Homebrew Launcher, either through the Homebrew Launcher icon on the HOME Menu or by re-following Section IV of this page
 1. Launch faketik from the list of homebrew
-1. Once faketik has finished processing, press (Start) to exit faketik
+1. Once faketik has finished processing, press <kbd>START</kbd> to exit faketik

--- a/docs/_include/format-sd-gm9.md
+++ b/docs/_include/format-sd-gm9.md
@@ -1,8 +1,8 @@
-1. Press (Home) to bring up the action menu
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "More..."
 1. Select "SD format menu"
 1. Select "No EmuNAND"
 1. Select "Auto"
-1. Press (A) to accept the label `GM9SD`
+1. Press <kbd>A</kbd> to accept the label `GM9SD`
     + Optionally, you may input a custom name for the SD card
 1. When prompted, input the key combo given to confirm

--- a/docs/_include/launch-hbl-dlp.md
+++ b/docs/_include/launch-hbl-dlp.md
@@ -1,13 +1,13 @@
 1. Launch the Download Play application (![](/images/download-play-icon.png){height="24px" width="24px"})
-1. Wait until you see the `Nintendo 3DS` and `Nintendo DS` buttons
-1. Press (Left Shoulder) + (D-Pad Down) + (Select) at the same time to open the Rosalina menu
+1. Wait until you see the _Nintendo 3DS_ and _Nintendo DS_ buttons
+1. Press <kbd>L+Down+Select</kbd> at the same time to open the Rosalina menu
 1. Select "Miscellaneous options"
 1. Select "Switch the hb. title to the current app."
-1. Press (B) to continue
-1. Press (B) to return to the Rosalina main menu
-1. Press (B) to exit the Rosalina menu
-1. Press (Home) to suspend Download Play
-1. Press the "Close" button on the bottom screen to close Download Play
+1. Press <kbd>B</kbd> to continue
+1. Press <kbd>B</kbd> to return to the Rosalina main menu
+1. Press <kbd>B</kbd> to exit the Rosalina menu
+1. Press <kbd>HOME</kbd> to suspend Download Play
+1. Press the _Close_ button on the bottom screen to close Download Play
 1. Re-launch the Download Play application
 1. Your console should load the Homebrew Launcher
     + If your console is stuck on the loading splash screen, you are missing `boot.3dsx` from the root of your SD card

--- a/docs/_include/nand-backup.md
+++ b/docs/_include/nand-backup.md
@@ -1,21 +1,21 @@
-1. Press (Home) to bring up the action menu
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"
 1. Select "Backup Options"
 1. Select "SysNAND Backup"
-1. Press (A) to confirm
+1. Press <kbd>A</kbd> to confirm
     + This process will take some time
     + If you get an error, look for your issue in the [troubleshooting guide](troubleshooting-finalizing-setup.html)
-1. Press (A) to continue
-1. Press (B) to return to the main menu
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>B</kbd> to return to the main menu
 1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
+1. Press <kbd>A</kbd> to relock write permissions if prompted
 1. Navigate to `[S:] SYSNAND VIRTUAL`
-1. Press (A) on `essential.exefs` to select it
+1. Press <kbd>A</kbd> on `essential.exefs` to select it
 1. Select "Copy to 0:/gm9/out"
-    + If you see "Destination already exists", press (A) on "Overwrite file(s)"
-1. Press (A) to continue
-1. Hold (R) and press (Start) at the same time to power off your console
+    + If you see "Destination already exists", press <kbd>A</kbd> on "Overwrite file(s)"
+1. Press <kbd>A</kbd> to continue
+1. Hold <kbd>R</kbd> and press <kbd>START</kbd> at the same time to power off your console
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_##.bin`, `<date>_<serialnumber>_sysnand_##.bin.sha`, and `essential.exefs` from the `/gm9/out/` folder on your SD card to a safe location on your computer
     + Copy these backups to multiple locations (such as online file storage, an external hard drive, etc.)

--- a/docs/a9lh-to-b9s.md
+++ b/docs/a9lh-to-b9s.md
@@ -58,8 +58,8 @@ For all steps in this section, if any of the files already exist, overwrite them
 
 ### Section II - Installing boot9strap
 
-1. Boot your console while holding (Start) to launch SafeB9SInstaller
-    + If you see the luma configuration screen instead of SafeB9SInstaller, simply press (Start), then shut down your 3DS and try again
+1. Boot your console while holding <kbd>START</kbd> to launch SafeB9SInstaller
+    + If you see the luma configuration screen instead of SafeB9SInstaller, simply press <kbd>START</kbd>, then shut down your 3DS and try again
     + If this gives you an error, try either using a new SD card or formatting your current SD card (backup existing files first)
 1. Wait for all safety checks to complete
     + If you get an "OTP Crypto Fail" error, download <font-awesome-icon icon="fa-solid fa-magnet"/> - [aeskeydb.bin](magnet:?xt=urn:btih:d25dab06a7e127922d70ddaa4fe896709dc99a1e&dn=aeskeydb.bin&tr=udp%3a%2f%2ftracker.tiny-vps.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.lelux.fi%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.loadbt.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.moeking.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.monitorit4.me%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.ololosh.space%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.pomf.se%3a80%2fannounce&tr=udp%3a%2f%2ftracker.srv00.com%3a6969%2fannounce&tr=udp%3a%2f%2ftracker.theoks.net%3a6969%2fannounce&tr=udp%3a%2f%2fopen.tracker.cl%3a1337%2fannounce&tr=udp%3a%2f%2ftracker.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.zerobytes.xyz%3a1337%2fannounce&tr=udp%3a%2f%2ftracker1.bt.moack.co.kr%3a80%2fannounce&tr=udp%3a%2f%2fvibe.sleepyinternetfun.xyz%3a1738%2fannounce&tr=udp%3a%2f%2fwww.torrent.eu.org%3a451%2fannounce&tr=udp%3a%2f%2ftracker.openbittorrent.com%3a6969%2fannounce&tr=udp%3a%2f%2f9.rarbg.com%3a2810%2fannounce&tr=udp%3a%2f%2ftracker.opentrackr.org%3a1337%2fannounce&tr=http%3a%2f%2fopenbittorrent.com%3a80%2fannounce&tr=udp%3a%2f%2fexodus.desync.com%3a6969%2fannounce), then put it in the `/boot9strap/` folder on your SD card and try again

--- a/docs/checking-for-cfw.md
+++ b/docs/checking-for-cfw.md
@@ -15,8 +15,8 @@ If your console has a menuhax-based CFW setup, you should [clear HOME Menu's ext
 ## Instructions
 
 1. Power off your console
-1. Hold the (Select) button
-1. Power on your console while still holding the (Select) button
+1. Hold the <kbd>SELECT</kbd> button
+1. Power on your console while still holding the <kbd>SELECT</kbd> button
 1. You should now see a configuration menu of some sort
 
 ## What to do next
@@ -47,7 +47,7 @@ If you see a Luma3DS version of 8.0 or greater, continue to [Restoring / Updatin
 
 ::: warning
 
-If you see GodMode9, Decrypt9WIP, Hourglass9, or Luma3DS chainloader, you held (Start) by accident and should try these instructions again with (Select)
+If you see GodMode9, Decrypt9WIP, Hourglass9, or Luma3DS chainloader, you held <kbd>START</kbd> by accident and should try these instructions again with <kbd>SELECT</kbd>
 
 :::
 

--- a/docs/ctrtransfer.md
+++ b/docs/ctrtransfer.md
@@ -40,7 +40,7 @@ As a part of this process, your system settings will be reset to its defaults. T
 
 ### Section II - NAND Backup
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 <!--@include: ./_include/nand-backup.md -->
 
 ### Section III - CTRTransfer

--- a/docs/dumping-titles-and-game-cartridges.md
+++ b/docs/dumping-titles-and-game-cartridges.md
@@ -40,11 +40,11 @@ Insert the game cartridge you intend to dump into your console
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[C:] GAMECART`
 1. Follow the steps applicable to your game cartridge:
-    + **3DS Game Cartridge:** Press (A) on `<TitleID>.trim.3ds` to select it
-    + **NDS Game Cartridge:** Press (A) on `<TitleID>.nds` to select it
+    + **3DS Game Cartridge:** Press <kbd>A</kbd> on `<TitleID>.trim.3ds` to select it
+    + **NDS Game Cartridge:** Press <kbd>A</kbd> on `<TitleID>.nds` to select it
         + Trimmed dumps are not recommended for NDS games in general, as they can cause various playback issues
 1. Select "Copy to 0:/gm9/out"
 1. Your non-installable `.3ds` or `.nds` formatted file will be outputted to the `/gm9/out/` folder on your SD card
@@ -57,10 +57,10 @@ This will only work for 3DS games; it is not possible to install an NDS game car
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[C:] GAMECART`
-1. Press (A) on `[TitleID].trim.3ds` to select it, then select "NCSD image options...", then select "Install game image"
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press <kbd>A</kbd> on `[TitleID].trim.3ds` to select it, then select "NCSD image options...", then select "Install game image"
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl1) writing, then input the key combo given
 1. Once the process is complete, your game will show up in the HOME Menu as an installed title.
 
 ## Dumping a 3DS Game Cartridge to .CIA
@@ -71,9 +71,9 @@ This should only be used if [Installing a Game Cartridge Directly to the System]
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[C:] GAMECART`
-1. Press (A) on `<TitleID>.trim.3ds` to select it, then select "NCSD image options...", then select "Build CIA from file"
+1. Press <kbd>A</kbd> on `<TitleID>.trim.3ds` to select it, then select "NCSD image options...", then select "Build CIA from file"
 1. Your installable `.cia` formatted file will be outputted to the `/gm9/out/` folder on your SD card
 
 ## Dumping an Installed Title
@@ -84,8 +84,8 @@ This allows dumping of both System- and User-installed digital titles, such as o
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Title manager"
 1. Select one of the following depending on the type of title you wish to dump
     + **User Installed Title**: `[A:] SD CARD`
@@ -105,7 +105,7 @@ The game will be outputted to the `/gm9/out/` folder on your SD card with the na
 
 ::: info
 
-To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by pressing (Home) to bring up the action menu, selecting `Title manager`, and selecting `[A:] SD CARD`.
+To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by pressing <kbd>HOME</kbd> to bring up the action menu, selecting `Title manager`, and selecting `[A:] SD CARD`.
 
 :::
 
@@ -113,19 +113,19 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
     + Launch the GBA VC game
     + Exit the GBA VC game
     + Power off your console
-    + Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+    + Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
     + Navigate to `[S:] SYSNAND VIRTUAL`
-    + Press (A) on `agbsave.bin` to select it
+    + Press <kbd>A</kbd> on `agbsave.bin` to select it
     + Select "AGBSAVE options..."
     + Select "Dump GBA VC save"
-    + Press (A) to continue
-    + Press (Start) to reboot your console
+    + Press <kbd>A</kbd> to continue
+    + Press <kbd>START</kbd> to reboot your console
 
 ## Restore GBA VC Saves
 
 ::: info
 
-To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by pressing (Home) to bring up the action menu, selecting `Title manager`, and selecting `[A:] SD CARD`.
+To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of all games on the system and their corresponding Title IDs by pressing <kbd>HOME</kbd> to bring up the action menu, selecting `Title manager`, and selecting `[A:] SD CARD`.
 
 :::
 
@@ -133,16 +133,16 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
     + Launch the GBA VC game
     + Exit the GBA VC game
     + Power off your console
-    + Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+    + Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
     + Navigate to `[0:] SDCARD` -> `gm9` -> `out`
-    + Press (Y) on the `<TitleID>.gbavc.sav` file you wish to restore to copy it
-    + Press (B) to return to the main menu
+    + Press <kbd>Y</kbd> on the `<TitleID>.gbavc.sav` file you wish to restore to copy it
+    + Press <kbd>B</kbd> to return to the main menu
     + Navigate to `[S:] SYSNAND VIRTUAL`
-    + Press (A) on `agbsave.bin` to select it
+    + Press <kbd>A</kbd> on `agbsave.bin` to select it
     + Select "AGBSAVE options..."
     + Select "Inject GBA VC save"
-    + Press (A) to continue
-    + Press (Start) to reboot your console
+    + Press <kbd>A</kbd> to continue
+    + Press <kbd>START</kbd> to reboot your console
     + Launch the GBA VC game
     + Exit the GBA VC game
 
@@ -154,9 +154,9 @@ For organizational purposes, copy each `.cia` file you wish to encrypt / decrypt
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[0:] SDCARD` -> `cias`
-1. Press (A) on the `.cia` file to select it, then select "CIA image options..."
+1. Press <kbd>A</kbd> on the `.cia` file to select it, then select "CIA image options..."
 1. Select the option to perform the desired function:
     + **Encrypt to 0:/gm9/out:** Create an encrypted copy of the selected `.cia` file in the `/gm9/out/` folder on your SD card
     + **Decrypt to 0:/gm9/out:** Create a decrypted copy of the selected `.cia` file in the `/gm9/out/` folder on your SD card

--- a/docs/finalizing-setup.md
+++ b/docs/finalizing-setup.md
@@ -84,40 +84,40 @@ In this section, you will update your system to the latest version, which is saf
 
 In this section, you will sync your 3DS internal clock with the actual time and dump the sound firmware (which is necesssary for some homebrew software to use sound properly).
 
-1. Press (Left Shoulder) + (D-Pad Down) + (Select) at the same time to open the Rosalina menu
-    + If one of these buttons is broken, download [config.ini](/assets/config.ini) and put it in your `luma` folder, replacing the existing one. This will change the Rosalina menu key combination to (X) + (Y)
+1. Press <kbd>L+Down+Select</kbd> at the same time to open the Rosalina menu
+    + If one of these buttons is broken, download [config.ini](/assets/config.ini) and put it in your `luma` folder, replacing the existing one. This will change the Rosalina menu key combination to <kbd>X+Y</kbd>
 1. Select "Miscellaneous options"
 1. Select "Dump DSP firmware"
-1. Press (B) to continue
+1. Press <kbd>B</kbd> to continue
 1. Select "Nullify user time offset"
-1. Press (B) to continue
-1. Press (B) to return to the Rosalina main menu
-1. Press (B) to exit the Rosalina menu
+1. Press <kbd>B</kbd> to continue
+1. Press <kbd>B</kbd> to return to the Rosalina main menu
+1. Press <kbd>B</kbd> to exit the Rosalina menu
 
 ### Section IV - Setup Script
 
 In this section, you will use a series of scripts to automate homebrew installation, SD card cleanup, and system file backup.
 
 1. Power off your console
-1. Press and hold (X), and while holding (X), power on your console. This will launch the Finalizing Setup Helper
+1. Press and hold <kbd>X</kbd>, and while holding <kbd>X</kbd>, power on your console. This will launch the Finalizing Setup Helper
     + If you boot to the HOME Menu, your `payloads` folder may be incorrectly spelled, or `x_finalize_helper.firm` may be in the wrong location
     + If you encounter an error, consult the [troubleshooting](troubleshooting-finalizing-setup) page
 1. After a few seconds, your console should automatically boot into GodMode9
-    + From this point forward, you can access GodMode9 by holding (Start) while powering on your console
-    + Holding (X) on boot will no longer do anything
+    + From this point forward, you can access GodMode9 by holding <kbd>START</kbd> while powering on your console
+    + Holding <kbd>X</kbd> on boot will no longer do anything
 1. If necessary, configure GodMode9:
-    + If you are prompted to select a language, use the D-Pad and press (A) to select English
+    + If you are prompted to select a language, use the D-Pad and press <kbd>A</kbd> to select English
         + This language choice only affects GodMode9's menu options
         + You can set it to your language of choice after completing this guide
-    + If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue
-    + If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
-1. Once you see [root] and a list of drives, press (Home) to bring up the action menu
+    + If you are prompted to create an essential files backup, press <kbd>A</kbd> to do so, then press <kbd>A</kbd> to continue
+    + If you are prompted to fix the RTC date&time, press <kbd>A</kbd> to do so, then set the date and time, then press <kbd>A</kbd> to continue
+1. Once you see [root] and a list of drives, press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..." (*not* Lua scripts)
 1. Select "finalize"
 1. Follow the prompts in the script, answering any questions that you are asked
-    + If you see "Information #05: No title database", press (A) and enter the key combination on the bottom screen to proceed
-    + If you encounter an error, follow the instructions in the error message or consult the [troubleshooting](troubleshooting-finalizing-setup) page, then open GodMode9 by holding (Start) on boot to re-run the script
-1. Once the script says "Setup complete!", press (A) to power off the device
+    + If you see "Information #05: No title database", press <kbd>A</kbd> and enter the key combination on the bottom screen to proceed
+    + If you encounter an error, follow the instructions in the error message or consult the [troubleshooting](troubleshooting-finalizing-setup) page, then open GodMode9 by holding <kbd>START</kbd> on boot to re-run the script
+1. Once the script says "Setup complete!", press <kbd>A</kbd> to power off the device
     + If you do NOT see the message "Setup complete!", the script was not successful and you will need to redo this section from Step 3
 1. Insert your SD card into your computer
 1. Copy the `/gm9/backups/` folder to a safe location on your computer
@@ -147,10 +147,10 @@ Trying to figure out what to do with your newly modded device? Visit [our wiki](
 
 Here are some key combos that you should know:
 
-+ Holding (Select) on boot will launch the Luma3DS configuration menu.
-+ Holding (Start) on boot will launch GodMode9, or if you have multiple payloads in `/luma/payloads/`, the Luma3DS chainloader.
-+ By default, pressing (Left Shoulder) + (Down D-Pad) + (Select) while in 3DS mode will open the Rosalina menu, where you can check system information, take screenshots, enable cheats, and more. This can be changed from the Rosalina menu.
-+ Holding (Start) + (Select) + (X) on boot will make the notification LED show a color for debug purposes. See the [changelog](https://github.com/SciresM/boot9strap/releases/tag/1.4) for a list.
++ Holding <kbd>SELECT</kbd> on boot will launch the Luma3DS configuration menu.
++ Holding <kbd>START</kbd> on boot will launch GodMode9, or if you have multiple payloads in `/luma/payloads/`, the Luma3DS chainloader.
++ By default, pressing <kbd>L+Down+Select</kbd> while in 3DS mode will open the Rosalina menu, where you can check system information, take screenshots, enable cheats, and more. This can be changed from the Rosalina menu.
++ Holding <kbd>START+SELECT+X</kbd> on boot will make the notification LED show a color for debug purposes. See the [changelog](https://github.com/SciresM/boot9strap/releases/tag/1.4) for a list.
 
 :::
 

--- a/docs/flashing-ntrboot-(3ds-multi-system).md
+++ b/docs/flashing-ntrboot-(3ds-multi-system).md
@@ -35,21 +35,21 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 ### Section II - Flashing ntrboot
 
-1. Launch the Luma3DS chainloader by holding (Start) during boot on **the source 3DS**
+1. Launch the Luma3DS chainloader by holding <kbd>START</kbd> during boot on **the source 3DS**
 1. Select "ntrboot_flasher"
 1. Read the red screen warning
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
 1. Select your flashcart
     + If you do not see your flashcart in the list at the top, read the bottom screen for more info on each option
 1. Select "Dump Flash"
 1. Wait until the process is completed
-1. Press (A) to continue
-1. Press (A) to return to the main menu
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to return to the main menu
 1. Select "Inject Ntrboot"
-1. Press (A) for retail unit ntrboot
+1. Press <kbd>A</kbd> for retail unit ntrboot
 1. Wait until the process is completed
-1. Press (A) to return to the main menu
-1. Press (B) to power off **the source 3DS**
+1. Press <kbd>A</kbd> to return to the main menu
+1. Press <kbd>B</kbd> to power off **the source 3DS**
 
 ___
 

--- a/docs/flashing-ntrboot-(3ds-single-system).md
+++ b/docs/flashing-ntrboot-(3ds-single-system).md
@@ -33,17 +33,17 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 ### Section II - Flashing ntrboot
 
 1. Launch `ntrboot_flasher_nds.nds` on your console using your flashcart
-1. Press (A) to continue
-1. Use (Up) and (Down) to select your flashcart
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
+1. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select your flashcart
+1. Press <kbd>A</kbd> to continue
 1. Select "Dump flash" to make a backup of your flashcart's memory
 1. Input the key combo given to confirm
-1. Press (A) to continue
-1. Use (Up) and (Down) to select your flashcart
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
+1. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select your flashcart
+1. Press <kbd>A</kbd> to continue
 1. Select "Inject FIRM" to install boot9strap to your flashcart
 1. Input the key combo given to confirm
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
 1. Power off your console
 
 ___

--- a/docs/flashing-ntrboot-(dsi).md
+++ b/docs/flashing-ntrboot-(dsi).md
@@ -33,12 +33,12 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 ### Section II - Flashing ntrboot
 
 1. Launch `ds_ntrboot_flasher_dsi.nds` on **the source DSi** using your flashcart
-1. Press (A) to continue
-1. Use (Up) and (Down) to select your flashcart
-1. Press (A) to continue
-1. Press (A) to "inject ntrboothax"
-1. Press (A) to select "RETAIL"
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
+1. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select your flashcart
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to "inject ntrboothax"
+1. Press <kbd>A</kbd> to select "RETAIL"
+1. Press <kbd>A</kbd> to continue
 1. Select "EXIT"
 
 ___

--- a/docs/flashing-ntrboot-(nds).md
+++ b/docs/flashing-ntrboot-(nds).md
@@ -36,17 +36,17 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 ### Section II - Flashing ntrboot
 
 1. Launch `ntrboot_flasher_nds.nds` on **the source NDS / NDSL** using your flashcart
-1. Press (A) to continue
-1. Use (Up) and (Down) to select your flashcart
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
+1. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select your flashcart
+1. Press <kbd>A</kbd> to continue
 1. Select "Dump flash" to make a backup of your flashcart's memory
 1. Input the key combo given to confirm
-1. Press (A) to continue
-1. Use (Up) and (Down) to select your flashcart
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
+1. Use <kbd>Up</kbd> and <kbd>Down</kbd> to select your flashcart
+1. Press <kbd>A</kbd> to continue
 1. Select "Inject FIRM" to install boot9strap to your flashcart
 1. Input the key combo given to confirm
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
 1. Power off **the source NDS / NDSL**
 1. Eject your flashcart from **the source NDS / NDSL**
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -18,8 +18,8 @@ Before starting this guide, we will see if custom firmware is already installed 
 
 1. Power off your console
 1. Insert your SD card into your console
-1. Hold the (Select) button
-1. Power on your console while still holding the (Select) button
+1. Hold the <kbd>Select</kbd> button
+1. Power on your console while still holding the <kbd>Select</kbd> button
 1. If you do not see a custom menu (your console just boots to the HOME Menu), you may proceed to the next section
 
 ::: warning

--- a/docs/godmode9-usage.md
+++ b/docs/godmode9-usage.md
@@ -16,7 +16,7 @@ For support (in English) with GodMode9, as well as help with scripting and to ge
 
 GodMode9 is a full access file browser for the Nintendo 3DS console, giving you access to your SD card, the FAT partitions inside your SysNAND and EmuNAND, and basically anything else. Among other functionality, you can copy, delete, rename files, and create folders.
 
-Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding (Start) on boot will display a "chainloader menu" where you will have to use the D-Pad and the (A) button to select "GodMode9" for these instructions.
+Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding <kbd>START</kbd> on boot will display a "chainloader menu" where you will have to use the D-Pad and the <kbd>A</kbd> button to select "GodMode9" for these instructions.
 
 GodMode9 is powerful software that has the capability to modify essentially anything on your console. Though many of these modifications are locked behind a permissions system, and it is impossible to accidentally perform dangerous actions without deliberately unlocking permissions, you should still follow instructions carefully and keep backups just in case.
 
@@ -48,7 +48,7 @@ GodMode9 is now up to date.
 
 ## Creating a NAND Backup
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 <!--@include: ./_include/nand-backup.md -->
 
 ::: tip
@@ -63,20 +63,20 @@ Your NAND backup has been successfully created.
 1. Insert your SD card into your computer
 1. Copy `<date>_<serialnumber>_sysnand_##.bin` from your computer to the `/gm9/out/` folder on your SD card
 1. Reinsert your SD card into your console
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"
 1. Select "Restore Options"
 1. Select "SysNAND Restore (safe)"
 1. Select your NAND backup
-1. Press (A) to unlock SysNAND (lvl3) writing, then input the key combo given
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl3) writing, then input the key combo given
     + This will **not** overwrite your boot9strap installation
     + This process will take some time
-1. Press (A) to continue
-1. Press (B) to return to the main menu
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>B</kbd> to return to the main menu
 1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
+1. Press <kbd>A</kbd> to relock write permissions if prompted
 
 ::: tip
 
@@ -92,17 +92,17 @@ Note that it is not possible to inject files into Health & Safety that are large
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[0:] SDCARD` -> `cias`
-1. Press (A) on your `.cia` to select it
+1. Press <kbd>A</kbd> on your `.cia` to select it
 1. Select "CIA image options..."
 1. Select "Mount image to drive"
-1. Press (A) on the `.app` file
+1. Press <kbd>A</kbd> on the `.app` file
 1. Select "NCCH image options"
 1. Select "Inject to H&S"
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-1. Press (A) to continue
-1. Press (A) to relock write permissions if prompted
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to relock write permissions if prompted
 
 ::: tip
 
@@ -118,12 +118,12 @@ This will only work if the Health & Safety injection was performed by GodMode9 (
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "More..."
 1. Select "Restore H&S"
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-1. Press (A) to relock write permissions if prompted
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press <kbd>A</kbd> to relock write permissions if prompted
 
 ::: tip
 
@@ -139,8 +139,8 @@ Health & Safety has been reverted to normal.
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Right Shoulder) + (B) to unmount the current SD card and insert the one you want to format
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press (Right Shoulder) + <kbd>B</kbd> to unmount the current SD card and insert the one you want to format
     + If GodMode9 shows an initialization error when inserting the SD Card to be formatted, it can safely be dismissed
 <!--@include: ./_include/format-sd-gm9.md -->
 
@@ -158,19 +158,19 @@ This process will only log you out of your NNID. You will still not be able to u
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"
 1. Select "Scripts from Plailect's Guide"
 1. Select "Remove NNID"
-1. Press (A) to continue
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
-1. Press (A) to continue
-1. Press (B) to return to the main menu
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>B</kbd> to return to the main menu
 1. Select "Exit"
-1. Press (A) to relock write permissions if prompted
-1. Press (Start) to reboot your console
+1. Press <kbd>A</kbd> to relock write permissions if prompted
+1. Press <kbd>START</kbd> to reboot your console
 
 ::: tip
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -28,7 +28,7 @@ Popular uses for custom firmware include:
 
 * Running homebrew software and games made for or ported to the Nintendo 3DS
 * Bypassing the region lock, allowing you to play games from other regions
-* HOME Menu customization, using community-created [themes and badges](https://themeplaza.art)
+* Customizing your HOME Menu using community-created [themes and badges](https://themeplaza.art)
 * Modification of games ("ROM hacks") through [LayeredFS](https://github.com/knight-ryu12/godmode9-layeredfs-usage/wiki/Using-Luma3DS'-layeredfs-(Only-version-8.0-and-higher))
 * Save data editing, backup, and restore
 * Emulation of older consoles, as well as native playback of DS and GBA games

--- a/docs/installing-boot9strap-(hardmod).md
+++ b/docs/installing-boot9strap-(hardmod).md
@@ -86,7 +86,7 @@ In this section, you will install custom firmware to the dumped NAND image, and 
 1. Flash your outputted `NAND-patched.bin` to your console with your hardmod
 1. Power off your console
 1. Disconnect your hardmod
-1. Press and hold (Select), and while holding (Select), power on your console
+1. Press and hold <kbd>SELECT</kbd>, and while holding <kbd>SELECT</kbd>, power on your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 <!--@include: ./_include/luma3ds-installed-note.md -->

--- a/docs/installing-boot9strap-(mset9-cli).md
+++ b/docs/installing-boot9strap-(mset9-cli).md
@@ -109,7 +109,7 @@ These instructions must be followed **EXACTLY**, so double-check EVERYTHING you 
 
 1. Power on your console, ensuring System Settings is selected
     + If System Settings is not selected, **[hover over](/images/screenshots/mset9/hover-settings.png)** the System Settings icon using the D-Pad, power your console off, then back on
-1. Press (A) to launch System Settings
+1. Press <kbd>A</kbd> to launch System Settings
 1. Navigate to `Data Management` -> `Nintendo 3DS` -> `Extra Data` ([image](/images/screenshots/mset9/settings-extdata.png))
 1. **Do not press any buttons or touch the screen**
 1. **With the console STILL ON, and without pressing any buttons or touching the screen**, remove your SD card from your console
@@ -132,7 +132,7 @@ In this section, you will install custom firmware onto your console.
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-mset9#sighaxed-firm-was-not-installed-check-lower-screen-for-more-info)
     + If the top screen is blank **and** you see "Crypto Status - all checks passed" on the bottom screen, you will have to enter key combo blindly. Press the following buttons on your console in this order:
         + D-Pad Left, D-Pad Down, D-Pad Right, D-Pad Up, A
-1. Once it is complete (all seven steps on the bottom screen are green), press (A) to reboot your console
+1. Once it is complete (all seven steps on the bottom screen are green), press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 ### Section IV - Removing MSET9

--- a/docs/installing-boot9strap-(mset9-cli-ios).md
+++ b/docs/installing-boot9strap-(mset9-cli-ios).md
@@ -98,7 +98,7 @@ These instructions must be followed **EXACTLY**, so double-check EVERYTHING you 
 
 1. Power on your console, ensuring System Settings is selected
     + If System Settings is not selected, **[hover over](/images/screenshots/mset9/hover-settings.png)** the System Settings icon using the D-Pad, power your console off, then back on
-1. Press (A) to launch System Settings
+1. Press <kbd>A</kbd> to launch System Settings
 1. Navigate to `Data Management` -> `Nintendo 3DS` -> `Extra Data` ([image](/images/screenshots/mset9/settings-extdata.png))
 1. **Do not press any buttons or touch the screen**
 1. **With the console STILL ON, and without pressing any buttons or touching the screen**, remove your SD card from your console
@@ -121,7 +121,7 @@ In this section, you will install custom firmware onto your console.
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-mset9#sighaxed-firm-was-not-installed-check-lower-screen-for-more-info)
     + If the top screen is blank **and** you see "Crypto Status - all checks passed" on the bottom screen, you will have to enter key combo blindly. Press the following buttons on your console in this order:
         + D-Pad Left, D-Pad Down, D-Pad Right, D-Pad Up, A
-1. Once it is complete (all seven steps on the bottom screen are green), press (A) to reboot your console
+1. Once it is complete (all seven steps on the bottom screen are green), press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 ### Section IV - Removing MSET9

--- a/docs/installing-boot9strap-(mset9-play-store).md
+++ b/docs/installing-boot9strap-(mset9-play-store).md
@@ -88,7 +88,7 @@ These instructions must be followed **EXACTLY**, so double-check EVERYTHING you 
 
 1. Power on your console, ensuring System Settings is selected
     + If System Settings is not selected, **[hover over](/images/screenshots/mset9/hover-settings.png)** the System Settings icon using the D-Pad, power your console off, then back on
-1. Press (A) to launch System Settings
+1. Press <kbd>A</kbd> to launch System Settings
 1. Navigate to `Data Management` -> `Nintendo 3DS` -> `Extra Data` ([image](/images/screenshots/mset9/settings-extdata.png))
 1. **Do not press any buttons or touch the screen**
 1. **With the console STILL ON, and without pressing any buttons or touching the screen**, remove your SD card from your console
@@ -109,7 +109,7 @@ In this section, you will install custom firmware onto your console.
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-mset9#sighaxed-firm-was-not-installed-check-lower-screen-for-more-info)
     + If the top screen is blank **and** you see "Crypto Status - all checks passed" on the bottom screen, you will have to enter key combo blindly. Press the following buttons on your console in this order:
         + D-Pad Left, D-Pad Down, D-Pad Right, D-Pad Up, A
-1. Once it is complete (all seven steps on the bottom screen are green), press (A) to reboot your console
+1. Once it is complete (all seven steps on the bottom screen are green), press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 ### Section IV - Removing MSET9

--- a/docs/installing-boot9strap-(ntrboot).md
+++ b/docs/installing-boot9strap-(ntrboot).md
@@ -41,7 +41,7 @@ To use the [magnet](https://wikipedia.org/wiki/Magnet_URI_scheme) links on this 
 1. Insert your flashcart into your console
 1. Place the magnet on your console to trigger the sleep sensor
     + On old 2DS, you should instead enable the sleep mode switch
-1. Hold (Start) + (Select) + (X) + (Power) for several seconds, then release the buttons
+1. Hold <kbd>START+SELECT+X+POWER</kbd> for several seconds, then release the buttons
     + It may take a few attempts to get this to work because the positioning is awkward
 1. If the exploit was successful, you will have booted into SafeB9SInstaller
 1. Remove the magnet from your console
@@ -131,13 +131,13 @@ Do not follow this section until you have completed the rest of the instructions
 1. Copy `ntrboot_flasher.firm` to the `/luma/payloads/` folder on your SD card
 1. Reinsert your SD card into your console
 1. Insert your ntrboot compatible DS / DSi flashcart into your console
-1. Launch ntrboot_flasher by holding (Start) during boot
+1. Launch ntrboot_flasher by holding <kbd>START</kbd> during boot
 1. Read the red screen warning
-1. Press (A) to continue
+1. Press <kbd>A</kbd> to continue
 1. Select your flashcart
     + If you do not see your flashcart in the list at the top, read the bottom screen for more info on each option
 1. Select "Restore Flash"
-1. Press (A) to proceed
+1. Press <kbd>A</kbd> to proceed
 1. Wait until the process is completed
-1. Press (A) to return to the main menu
-1. Press (B) to power off your console
+1. Press <kbd>A</kbd> to return to the main menu
+1. Press <kbd>B</kbd> to power off your console

--- a/docs/installing-boot9strap-(safecerthax).md
+++ b/docs/installing-boot9strap-(safecerthax).md
@@ -28,7 +28,7 @@ This exploit will not work on the New 3DS, New 3DS XL, or New 2DS XL. Please ens
 In this section, you will see whether your shoulder buttons are working on your console. This will determine whether your console is compatible with this method.
 
 1. Power on your console
-1. Once you see the HOME Menu, press the (Left Shoulder) and (Right Shoulder) buttons at the same time
+1. Once you see the HOME Menu, press the <kbd>L+R</kbd> buttons at the same time
     + The camera applet should appear
 1. Power off your console
 
@@ -80,7 +80,7 @@ In this section, you will change your Internet connection settings to use a prox
 
 In this section, you will enter Safe Mode (a feature available on all 3DS family consoles) where safecerthax will be triggered, which will launch you into the boot9strap (custom firmware) installer.
 
-1. With your console still powered off, hold the following buttons: (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A), and while holding these buttons together, power on your console
+1. With your console still powered off, hold the following buttons: <kbd>L+R+Up+A</kbd>, and while holding these buttons together, power on your console
     + Keep holding the buttons until the console boots into Safe Mode (a "system update" menu)
 1. Press "OK" to accept the update
     + There is no update. This is part of the exploit
@@ -96,7 +96,7 @@ In this section, you will install custom firmware onto your console.
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-safecerthax)
-1. Once it is complete, press (A) to reboot your console
+1. Once it is complete, press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 <!--@include: ./_include/luma3ds-installed-note.md -->

--- a/docs/installing-boot9strap-(soundhax).md
+++ b/docs/installing-boot9strap-(soundhax).md
@@ -90,7 +90,7 @@ In this section, you will install custom firmware onto your console.
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-soundhax)
-1. Once it is complete, press (A) to reboot your console
+1. Once it is complete, press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 <!--@include: ./_include/luma3ds-installed-note.md -->

--- a/docs/installing-boot9strap-(ssloth-browser).md
+++ b/docs/installing-boot9strap-(ssloth-browser).md
@@ -63,10 +63,10 @@ In this section, you will change your Internet connection settings to use a prox
 
 In this section, you will visit the browser exploit webpage, which will use universal-otherapp to launch the boot9strap (custom firmware) installer.
 
-1. On the HOME Menu, press the Left and Right shoulder buttons at the same time to open the camera
+1. On the HOME Menu, press the <kbd>L+R</kbd> buttons at the same time to open the camera
     + If you are unable to open the camera, open the Internet Browser and manually type the URL instead (`https://zoogie.github.io/web/nbhax/`)
 1. Tap the QR code button and scan [this QR code](http://api.qrserver.com/v1/create-qr-code/?color=000000&bgcolor=FFFFFF&data=https%3A%2F%2Fzoogie.github.io%2Fweb%2Fnbhax&qzone=1&margin=0&size=400x400&ecc=L)
-    + When you get a prompt with error code `012-1511`, `032-1809` or `032-1820`, press (A) to allow the connection
+    + When you get a prompt with error code `012-1511`, `032-1809` or `032-1820`, press <kbd>A</kbd> to allow the connection
     + If you get a crash or a different error code, [follow this troubleshooting guide](troubleshooting-ssloth-browser)
 
     ::: danger
@@ -86,7 +86,7 @@ In this section, you will install custom firmware onto your console.
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-ssloth-browser)
-1. Once it is complete, press (A) to reboot your console
+1. Once it is complete, press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 ### Section V - Restoring default proxy

--- a/docs/installing-boot9strap-(super-skaterhax).md
+++ b/docs/installing-boot9strap-(super-skaterhax).md
@@ -86,7 +86,7 @@ A video detailing these steps is available [here](https://www.youtube.com/watch?
 1. Tap on `Settings` -> `Delete Cookies` -> `Yes`
 1. Press (Home) to return to the HOME Menu, then immediately reopen the Internet Browser
 1. Wait for the page to fully load, then tap the "GO GO!" button on the top of the bottom screen
-1. Wait for the page to fully load, then press (A) to dismiss the [popup](/images/screenshots/skaterhax/skater-popup.png)
+1. Wait for the page to fully load, then press <kbd>A</kbd> to dismiss the [popup](/images/screenshots/skaterhax/skater-popup.png)
 1. If your console displays:
     + **"The Homebrew Launcher" screen**: Continue to the next step
     + **A white "Error has occurred" message box**: The exploit failed due to random chance. Open System Settings, change the language to a different one (if possible), then retry this section. You may have to repeat this sequence up to ten times
@@ -106,7 +106,7 @@ In this section, you will install custom firmware onto your console.
 
 1. When prompted, input the key combo given on the top screen to install boot9strap
     + If a step on the lower screen has red-colored text, and you are not prompted to input a key combo, [follow this troubleshooting guide](troubleshooting-super-skaterhax)
-1. Once it is complete, press (A) to reboot your console
+1. Once it is complete, press <kbd>A</kbd> to reboot your console
 <!--@include: ./_include/configure-luma3ds.md -->
 
 <!--@include: ./_include/luma3ds-installed-note.md -->

--- a/docs/move-emunand.md
+++ b/docs/move-emunand.md
@@ -4,7 +4,7 @@
 
 This is an add-on section for moving the contents of a previous EmuNAND to your new SysNAND CFW, then removing the old EmuNAND partition. Note that the terms EmuNAND and RedNAND refer to slightly different implementations of [the same concept](http://3dbrew.org/wiki/NAND_Redirection).
 
-Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding (Start) on boot will display a "chainloader menu" where you will have to use the D-Pad and the (A) button to select "GodMode9" for these instructions.
+Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding <kbd>START</kbd> on boot will display a "chainloader menu" where you will have to use the D-Pad and the <kbd>A</kbd> button to select "GodMode9" for these instructions.
 
 ::: danger
 
@@ -35,14 +35,14 @@ If you do not have any DSiWare games or saves that you care about, skip this sec
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is completed
-1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. If you are prompted to create an essential files backup, press <kbd>A</kbd> to do so, then press <kbd>A</kbd> to continue once it is completed
+1. If you are prompted to fix the RTC date&time, press <kbd>A</kbd> to do so, then set the date and time, then press <kbd>A</kbd> to continue
     + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after this guide
 1. Navigate to `[2:] SYSNAND TWLN` -> `title`
-1. Hold (R) and press (A) at the same time on `00030004` to select the folder, then select "Copy to 0:/gm9/out"
+1. Hold <kbd>R</kbd> and press <kbd>A</kbd> at the same time on `00030004` to select the folder, then select "Copy to 0:/gm9/out"
     + This process may take some time if you have many DSiWare games
-1. Press (B) twice to return to the main menu
+1. Press <kbd>B</kbd> twice to return to the main menu
 
 ### Section III - Backup GBA VC Saves
 
@@ -75,27 +75,27 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 1. Do the following process for each GBA VC game that you want to back up the save for:
     + Launch the GBA VC game
     + Exit the GBA VC game
-    + Boot your console while holding (Start) to launch the Luma3DS chainloader menu
-    + Launch GodMode9 by pressing (A)
+    + Boot your console while holding <kbd>START</kbd> to launch the Luma3DS chainloader menu
+    + Launch GodMode9 by pressing <kbd>A</kbd>
     + Navigate to `[S:] SYSNAND VIRTUAL`
-    + Press (A) on `agbsave.bin` to select it
+    + Press <kbd>A</kbd> on `agbsave.bin` to select it
     + Select "AGBSAVE options..."
     + Select "Dump GBA VC save"
-    + Press (A) to continue
-    + Press (Start) to reboot your console
+    + Press <kbd>A</kbd> to continue
+    + Press <kbd>START</kbd> to reboot your console
 
 ### Section IV - Copy EmuNAND to SysNAND
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Navigate to `[E:] EMUNAND VIRTUAL`
-1. Press (A) on `nand.bin` to select it, then select "NAND image options...", then select "Restore SysNAND (safe)"
-1. Press (A) to unlock SysNAND overwriting, then input the key combo given
+1. Press <kbd>A</kbd> on `nand.bin` to select it, then select "NAND image options...", then select "Restore SysNAND (safe)"
+1. Press <kbd>A</kbd> to unlock SysNAND overwriting, then input the key combo given
     + This will not overwrite your boot9strap installation
 1. Input the key combo given to unlock SysNAND (lvl1) writing
     + This process will take some time
-1. Once it is completed, press (A) to continue
-1. Press (B) to decline relocking write permissions if prompted
-1. Press (B) to return to the main menu
+1. Once it is completed, press <kbd>A</kbd> to continue
+1. Press <kbd>B</kbd> to decline relocking write permissions if prompted
+1. Press <kbd>B</kbd> to return to the main menu
 
 ### Section V - Restore DSiWare Saves
 
@@ -106,16 +106,16 @@ If you did not backup DSiWare Saves earlier, skip this section.
 :::
 
 1. Navigate to `[0:] SDCARD` -> `gm9` -> `out`
-1. Press (Y) on the `00030004` folder to copy it
-1. Press (B) twice to return to the main menu
+1. Press <kbd>Y</kbd> on the `00030004` folder to copy it
+1. Press <kbd>B</kbd> twice to return to the main menu
 1. Navigate to `[2:] SYSNAND TWLN` -> `title`
-1. Press (Y) to paste the `00030004` folder
+1. Press <kbd>Y</kbd> to paste the `00030004` folder
 1. Select "Copy path(s)"
-1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl1) writing, then input the key combo given
 1. Select "Overwrite file(s)"
     + This process may take some time if you have many DSiWare games
-1. Press (B) to decline relocking write permissions if prompted
-1. Press (B) twice to return to the main menu
+1. Press <kbd>B</kbd> to decline relocking write permissions if prompted
+1. Press <kbd>B</kbd> twice to return to the main menu
 
 ### Section VI - Restore GBA VC Saves
 
@@ -131,42 +131,42 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 
 :::
 
-1. Hold (R) and press (Start) at the same time to power off your console
+1. Hold <kbd>R</kbd> and press <kbd>START</kbd> at the same time to power off your console
 1. Power on your console into SysNAND
 1. Do the following process for each GBA VC game that you want to restore the save for:
     + Launch the GBA VC game
     + Exit the GBA VC game
-    + Boot your console while holding (Start) to launch the Luma3DS chainloader menu
-    + Launch GodMode9 by pressing (A)
+    + Boot your console while holding <kbd>START</kbd> to launch the Luma3DS chainloader menu
+    + Launch GodMode9 by pressing <kbd>A</kbd>
     + Navigate to `[0:] SDCARD` -> `gm9`
-    + Press (Y) on the `<TitleID>.gbavc.sav` file you wish to restore to copy it
-    + Press (B) to return to the main menu
+    + Press <kbd>Y</kbd> on the `<TitleID>.gbavc.sav` file you wish to restore to copy it
+    + Press <kbd>B</kbd> to return to the main menu
     + Navigate to `[S:] SYSNAND VIRTUAL`
-    + Press (A) on `agbsave.bin` to select it
+    + Press <kbd>A</kbd> on `agbsave.bin` to select it
     + Select "AGBSAVE options..."
     + Select "Inject GBA VC save"
-    + Press (A) to continue
-    + Press (Start) to reboot your console
+    + Press <kbd>A</kbd> to continue
+    + Press <kbd>START</kbd> to reboot your console
     + Launch the GBA VC game
     + Exit the GBA VC game
 
 ### Section VII - Backup SysNAND
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 <!--@include: ./_include/nand-backup.md -->
 1. **Backup every file on your SD card to a folder on your computer; all files will be deleted in the following steps**
 
 ### Section VIII - Format SD card
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 <!--@include: ./_include/format-sd-gm9.md -->
-1. Hold (R) and press (B) at the same time to eject your SD card
+1. Hold <kbd>R</kbd> and press <kbd>B</kbd> at the same time to eject your SD card
 1. Insert your SD card into your computer
 1. Copy all your files back to your SD card
     + Ensure you replace the `boot.firm` file on your SD card with the one from your backup
 1. Reinsert your SD card into your console
-1. Press (A) to remount your SD card
-1. Press (Start) to reboot
+1. Press <kbd>A</kbd> to remount your SD card
+1. Press <kbd>START</kbd> to reboot
 
 ___
 

--- a/docs/ntrboot.md
+++ b/docs/ntrboot.md
@@ -47,7 +47,7 @@ The usage of this exploit, regardless of the flashing method, requires access to
 
 ::: info
 
-To test if a magnet will work, hold it on or around the (A)(B)(X)(Y) buttons while the console is powered on to see if it triggers sleep mode. If it does, both displays will go black as long as the magnet is held in that spot.
+To test if a magnet will work, hold it on or around the <kbd>ABXY</kbd> buttons while the console is powered on to see if it triggers sleep mode. If it does, both displays will go black as long as the magnet is held in that spot.
 
 :::
 

--- a/docs/region-changing.md
+++ b/docs/region-changing.md
@@ -56,7 +56,7 @@ If you change the region of your console:
 
 ### Section II - NAND Backup
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 <!--@include: ./_include/nand-backup.md -->
 
 ### Section III - CTRTransfer

--- a/docs/restoring-updating-cfw.md
+++ b/docs/restoring-updating-cfw.md
@@ -17,7 +17,7 @@ Your SD card must be formatted as FAT32 to follow this guide, or else the 3DS wi
     + The root of the SD card refers to the initial directory on your SD card where you can see the Nintendo 3DS folder, but are not inside of it
 1. Reinsert your SD card into your console
 1. Power on your console
-    + If you see the Luma3DS configuration menu, press (Start) to save and reboot
+    + If you see the Luma3DS configuration menu, press <kbd>START</kbd> to save and reboot
 
 ::: info
 

--- a/docs/troubleshooting-finalizing-setup.md
+++ b/docs/troubleshooting-finalizing-setup.md
@@ -11,7 +11,7 @@ The steps below can be attempted in any order, but are listed from easiest to ha
 1. If you are using Pretendo, switch back to Nintendo with Nimbus and try again
 1. Set your DNS settings to "Auto"
 1. Move closer to your WiFi router
-1. Update from Safe Mode by turning off the console, holding (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A) on boot, and following the on-screen prompts
+1. Update from Safe Mode by turning off the console, holding <kbd>L+R+Up+A</kbd> on boot, and following the on-screen prompts
 1. Delete your WiFi connection, then reconnect to your WiFi again
 1. Reboot your WiFi router
 1. Connect to a different WiFi connection, like a mobile hotspot
@@ -30,7 +30,7 @@ The file `finalize.romfs` is corrupt or unreadable. [Re-download it](https://git
 
 ::: details Information #23: finalize.romfs in wrong location
 
-The file `finalize.romfs` was placed in the wrong location instead of root of SD. The script will attempt to resolve this, but requires your permission to do so. Press (A) on the next few prompts to continue.
+The file `finalize.romfs` was placed in the wrong location instead of root of SD. The script will attempt to resolve this, but requires your permission to do so. Press <kbd>A</kbd> on the next few prompts to continue.
 
 :::
 
@@ -44,7 +44,7 @@ Ensure that your SD card is not [locked](/images/sdlock.png). If the SD card is 
 
 ::: details Error #02: Missing essential.exefs
 
-You said 'No' to the "Make essential files backup?" prompt in GodMode9. Power off your console, power it on while holding (Start) to re-enter GodMode9, say 'Yes' to the prompt, then try again.
+You said 'No' to the "Make essential files backup?" prompt in GodMode9. Power off your console, power it on while holding <kbd>START</kbd> to re-enter GodMode9, say 'Yes' to the prompt, then try again.
 
 :::
 
@@ -57,13 +57,13 @@ You need at least 1.3GB of free space to perform the NAND backup, which is a par
 1. Copy the `Nintendo 3DS` folder from the root of your SD card to your computer
 1. Delete the Nintendo 3DS folder from the SD card
 1. Reinsert your SD card into your console
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press the (Home) button
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press the <kbd>HOME</kbd> button
 1. Select "Scripts..."
 1. Select "finalize"
-1. Press (A) to create a NAND backup
+1. Press <kbd>A</kbd> to create a NAND backup
     + This may take around fifteen minutes
-1. Press (A) again
+1. Press <kbd>A</kbd> again
     + The console should automatically power off
 1. Insert your SD card into your computer
 1. Copy the files in `/gm9/backups/` on your SD to a safe location on your computer
@@ -74,8 +74,8 @@ You need at least 1.3GB of free space to perform the NAND backup, which is a par
 Now that you have your NAND backup in a safe place:
 
 1. Reinsert your SD card into your console
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press the (Home) button
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press the <kbd>HOME</kbd> button
 1. Select "Scripts..."
 1. Select "finalize"
 1. Continue the script as normal
@@ -85,7 +85,7 @@ Now that you have your NAND backup in a safe place:
 
 ::: details Information #05: No title database
 
-Press (A) to import a title database, unlock SysNAND writing by entering the buttons on-screen, then continue the script as normal.
+Press <kbd>A</kbd> to import a title database, unlock SysNAND writing by entering the buttons on-screen, then continue the script as normal.
 
 :::
 
@@ -97,7 +97,7 @@ Make sure you have at least 1.3GB available in your SD card. If you don't have e
 1. Copy the `Nintendo 3DS` folder from the root of your SD card to your computer
 1. Delete the Nintendo 3DS folder from the SD card
 1. Reinsert your SD card into your console
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
 1. Perform a [NAND Backup](godmode9-usage#creating-a-nand-backup)
 1. Copy the files in `gm9/out` on your SD to a safe location on your computer
 1. Delete the `<date>_<serialnumber>_sysnand_##.bin` and `<date>_<serialnumber>_sysnand_##.bin.sha` files from the SD card, keeping essential.exefs in `/gm9/out/`
@@ -118,14 +118,14 @@ Ensure that your SD card is not [locked](/images/sdlock.png). If the SD card is 
 
 The script has detected that the Nintendo 3DS folder is missing AND that you have already made a NAND backup before. If you intend to install homebrew applications, you should do the following:
 
-1. Press (B) to cancel making another NAND backup
-1. Hold (R) and press (Start) at the same time to power off your console
+1. Press <kbd>B</kbd> to cancel making another NAND backup
+1. Hold <kbd>R</kbd> and press <kbd>START</kbd> at the same time to power off your console
 1. Copy the contents of `/gm9/backups/` to a safe location on your computer
 1. Delete `/gm9/backups/` from your SD card
 1. If you moved your Nintendo 3DS folder off of your SD card to get to this point, copy it back to your SD card
     + If you do not have a Nintendo 3DS folder, boot into the HOME Menu at least once with the SD card inserted to automatically generate it
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "finalize"
 1. Follow the prompts in the script, answering any questions that you are asked 

--- a/docs/troubleshooting-post-install.md
+++ b/docs/troubleshooting-post-install.md
@@ -45,7 +45,7 @@ The steps below can be attempted in any order, but are listed from least to most
         + **TWN Region**: `000000B1`
 1. Try booting into recovery mode and updating your system:
     + Power off your console
-    + Hold (Left Shoulder) + (Right Shoulder) + (D-Pad Up) + (A)
+    + Hold <kbd>L+R+Up+A</kbd>
     + Power on your console
     + If you were successful, the console will boot to an "update your system" screen
 1. Follow the [CTRTransfer](ctrtransfer) guide
@@ -71,8 +71,8 @@ There are a number of reasons as to why this could be happening. In any case, th
 
 ARM11 exception handlers are disabled, or custom firmware is not installed. Try enabling ARM11 exception handlers:
 + Power off your console
-+ Hold (Select)
-+ Power on your console, while still holding (Select)
++ Hold <kbd>SELECT</kbd>
++ Power on your console, while still holding <kbd>SELECT</kbd>
 + If the "Disable ARM11 exception handlers" box is checked, uncheck it
 
 :::
@@ -114,8 +114,8 @@ Please take a photo of the error and join [Nintendo Homebrew on Discord](https:/
 1. Reinsert your SD card into your console
 1. Open the Homebrew Launcher
 1. Launch TWLFix-CFW from the list of homebrew
-1. Press (A) to uninstall the broken TWL titles
-1. Press (Start) to reboot the console
+1. Press <kbd>A</kbd> to uninstall the broken TWL titles
+1. Press <kbd>START</kbd> to reboot the console
 1. Update your console by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
     + The update will see that the essential TWL titles have been uninstalled, and will redownload and reinstall them
 1. Once the update is complete, tap "OK" to reboot the console

--- a/docs/uninstall-cfw.md
+++ b/docs/uninstall-cfw.md
@@ -90,14 +90,14 @@ If either of these tests has failed, DS mode, DS Download Play, and/or DS Connec
 ### Section III - Safety Test
 The purpose of this section is to verify that the console will boot and that critical system functions, like System Settings and the keyboard, will work once CFW is uninstalled. **If you skip this section, you may BRICK your console!**
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. If you are prompted to create an essential files backup, press (A) to do so, then press (A) to continue once it is complete
-1. If you are prompted to fix the RTC date&time, press (A) to do so, then set the date and time, then press (A) to continue
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. If you are prompted to create an essential files backup, press <kbd>A</kbd> to do so, then press <kbd>A</kbd> to continue once it is complete
+1. If you are prompted to fix the RTC date&time, press <kbd>A</kbd> to do so, then set the date and time, then press <kbd>A</kbd> to continue
     + Note that, if you had to fix the RTC date and time, you will have to fix the time in the System Settings as well after following this guide
-1. Press (Home) to bring up the action menu
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "safety_test"
-1. Read the text on-screen and press (A) to continue
+1. Read the text on-screen and press <kbd>A</kbd> to continue
 1. You should boot into the regular 3DS HOME Menu (any custom theme is irrelevant). If you do, continue these instructions
     + If you do not boot into the regular 3DS HOME Menu (black screen, error screen, etc.), uninstalling CFW **WILL BRICK YOUR CONSOLE!**
 1. Launch System Settings on your console
@@ -117,18 +117,18 @@ If you do NOT boot into the regular 3DS HOME Menu, or System Settings / your key
 
 ### Section IV - NAND Backup
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "GM9Megascript"
 1. Select "Backup Options"
 1. Select "SysNAND Backup"
-1. Press (A) to confirm
+1. Press <kbd>A</kbd> to confirm
     + This process will take some time
     + If you get an error, ensure you have at least 1.3GB of free space on your SD card
-1. Press (B) to return to the main menu
+1. Press <kbd>B</kbd> to return to the main menu
 1. Select “Exit”
-1. Press (Home) to bring up the action menu
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Poweroff system" to power off your console
 
 ### Section V - Removing illegitimate content
@@ -151,13 +151,13 @@ This section will remove illegitimate content, like homebrew and dumped cartridg
 1. Exit the System Settings application
 1. Launch the Download Play application (![](/images/download-play-icon.png){height="24px" width="24px"})
 1. Wait until you see the two buttons
-1. Press (Left Shoulder) + (D-Pad Down) + (Select) at the same time to open the Rosalina menu
+1. Press <kbd>L+Down+Select</kbd> at the same time to open the Rosalina menu
 1. Select "Miscellaneous options"
 1. Select "Switch the hb. title to the current app."
-1. Press (B) to continue
-1. Press (B) to return to the Rosalina main menu
-1. Press (B) to exit the Rosalina menu
-1. Press (Home), then close Download Play
+1. Press <kbd>B</kbd> to continue
+1. Press <kbd>B</kbd> to return to the Rosalina main menu
+1. Press <kbd>B</kbd> to exit the Rosalina menu
+1. Press <kbd>HOME</kbd>, then close Download Play
 1. Launch the Download Play application (![](/images/download-play-icon.png){height="24px" width="24px"})
 1. Your console should load the Homebrew Launcher
 1. Launch DSiWare Uninstaller from the list of homebrew
@@ -198,17 +198,17 @@ If you're removing CFW because:
 
 :::
 
-1. Press and hold (Start), and while holding (Start), power on your console. This will launch GodMode9
-    + If you instead see the Luma3DS chainloader, use the D-Pad and the (A) button to select GodMode9
-1. Press (Home) to bring up the action menu
+1. Press and hold <kbd>START</kbd>, and while holding <kbd>START</kbd>, power on your console. This will launch GodMode9
+    + If you instead see the Luma3DS chainloader, use the D-Pad and the <kbd>A</kbd> button to select GodMode9
+1. Press <kbd>HOME</kbd> to bring up the action menu
 1. Select "Scripts..."
 1. Select "uninstall_cfw"
-1. When prompted, press (A) to proceed
-2. Press (A) again to proceed
-1. Press (A) to unlock SysNAND (lvl3) writing, then input the key combo given
-1. Press (A) to continue
-1. Press (A) to relock write permissions if prompted
-1. Press (Start) to reboot your console
+1. When prompted, press <kbd>A</kbd> to proceed
+2. Press <kbd>A</kbd> again to proceed
+1. Press <kbd>A</kbd> to unlock SysNAND (lvl3) writing, then input the key combo given
+1. Press <kbd>A</kbd> to continue
+1. Press <kbd>A</kbd> to relock write permissions if prompted
+1. Press <kbd>START</kbd> to reboot your console
 
 ___
 

--- a/docs/updating-b9s.md
+++ b/docs/updating-b9s.md
@@ -47,7 +47,7 @@ For all steps in this section, overwrite any existing files on your SD card.
 1. Copy everything from the Luma3DS `.zip` to the root of your SD card, replacing any existing files
 1. Reinsert your SD card into your console
 1. Power on your console
-1. If your console has booted into the Luma3DS configuration menu, press (Start) to save and reboot
+1. If your console has booted into the Luma3DS configuration menu, press <kbd>START</kbd> to save and reboot
     + Luma3DS configuration menu are settings for the Luma3DS custom firmware. Many of these settings may be useful for customization or debugging
     + For the purpose of this guide, these settings will be left on default settings
 


### PR DESCRIPTION
Instead of putting them in brackets, console buttons should use \<kbd> tags.
Example: Use `<kbd>START</kbd>` and `<kbd>A</kbd>` instead of `(Start)` and `(A)`.