### PR TITLE
Run MSET9 from outside SD card

### DIFF
--- a/docs/_include/mset9-chorus.md
+++ b/docs/_include/mset9-chorus.md
@@ -1,5 +1,6 @@
 1. Run the MSET9 script:
     + **Windows**: Double-click `MSET9-Windows` (or `MSET9-Windows.bat`)
     + **macOS**: Double-click `MSET9-macOS.command` and enter your password if prompted
-    + **Linux**: Double-click `MSET9-Linux.desktop`
+    + **Linux**: Mount your SD card by selecting it in your file manager, then double-click `MSET9` (or `MSET9-Linux.desktop`) from your Desktop
+        + `MSET9-Linux.desktop` will not run on Linux from the SD card. It must be on your Desktop
         + Alternatively, open a Terminal window, `cd` to the root of your SD card, then type `python3 mset9.py` and press Enter

--- a/docs/installing-boot9strap-(mset9-cli).md
+++ b/docs/installing-boot9strap-(mset9-cli).md
@@ -54,6 +54,8 @@ In this section, you will prepare the MSET9 exploit by **temporarily** creating 
 
     :::
 
+    + **Linux only**: Move `MSET9-Linux.desktop` from the SD card to your Desktop folder.
+
 <!--@include: ./_include/mset9-chorus.md -->
     ::: info
 


### PR DESCRIPTION
Apparently, you can't run .desktop files from FAT32 cuz permissions and stuff. Anyways, merge this first: https://github.com/hacks-guide/MSET9/pull/20 and update the release like last time.

Also, maybe let's have someone else check to make sure it all works other than me first lol.